### PR TITLE
Add hover tooltips to action buttons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ qt_add_qml_module(prism_app
         qml/components/StateLayer.qml
         qml/components/Mask.qml
         qml/components/StyledScrollBar.qml
+        qml/components/StyledToolTip.qml
         qml/components/CachingIconImage.qml
         qml/components/filedialog/Sizes.qml
         qml/components/filedialog/CurrentItem.qml

--- a/qml/components/StyledToolTip.qml
+++ b/qml/components/StyledToolTip.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import QtQuick.Controls
+import prism
+
+ToolTip {
+    id: root
+
+    property color textColor: Colours.palette.m3onSurface
+    property color backgroundColor: Colours.palette.m3surfaceContainerHighest
+    property color borderColor: Qt.alpha(Colours.palette.m3outlineVariant, 0.4)
+
+    delay: Tokens.anim.durations.normal
+    timeout: Tokens.anim.durations.extraLarge * 5
+
+    topPadding: Tokens.padding.extraSmall
+    bottomPadding: Tokens.padding.extraSmall
+    leftPadding: Tokens.padding.small
+    rightPadding: Tokens.padding.small
+
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+    contentItem: StyledText {
+        text: root.text
+        font: Tokens.font.label.small
+        color: root.textColor
+    }
+
+    background: StyledRect {
+        radius: Tokens.rounding.small
+        color: root.backgroundColor
+        border.color: root.borderColor
+        border.width: 1
+    }
+
+    enter: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 0.0
+            to: 1.0
+            duration: Tokens.anim.durations.expressiveFastEffects
+            easing: Tokens.anim.expressiveFastEffects
+        }
+    }
+
+    exit: Transition {
+        NumberAnimation {
+            property: "opacity"
+            from: 1.0
+            to: 0.0
+            duration: Tokens.anim.durations.expressiveFastEffects
+            easing: Tokens.anim.expressiveFastEffects
+        }
+    }
+}

--- a/qml/components/dialogs/GitModal.qml
+++ b/qml/components/dialogs/GitModal.qml
@@ -212,6 +212,7 @@ MouseArea {
 
             // Tab 0: Branches List
             ListView {
+                id: branchesList
                 visible: root.currentTab === 0
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -224,7 +225,7 @@ MouseArea {
                     required property string modelData
                     readonly property bool isCurrent: modelData === GitManager.branchName
 
-                    width: parent.width
+                    width: branchesList.width
                     implicitHeight: 40
                     radius: Tokens.rounding.small
                     color: isCurrent ? Qt.alpha(Colours.palette.m3tertiary, 0.18) : (bHover.containsMouse ? Colours.tPalette.m3surfaceContainerHigh : "transparent")
@@ -272,6 +273,7 @@ MouseArea {
 
             // Tab 1: Commits History Feed
             ListView {
+                id: commitsList
                 visible: root.currentTab === 1
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -283,7 +285,7 @@ MouseArea {
                     id: commitItem
                     required property var modelData
 
-                    width: parent.width
+                    width: commitsList.width
                     implicitHeight: commitCol.implicitHeight + 12
                     radius: Tokens.rounding.small
                     color: Colours.tPalette.m3surfaceContainerHigh

--- a/qml/components/dialogs/PlacesManageModal.qml
+++ b/qml/components/dialogs/PlacesManageModal.qml
@@ -96,6 +96,11 @@ MouseArea {
                         cursorShape: Qt.PointingHandCursor
                         onClicked: root.expanded = false
                     }
+
+                    StyledToolTip {
+                        text: qsTr("Close")
+                        visible: closeHover.containsMouse
+                    }
                 }
             }
 
@@ -187,6 +192,11 @@ MouseArea {
                                 cursorShape: placeRowCard.index > 0 ? Qt.PointingHandCursor : undefined
                                 onClicked: PlacesModel.movePlace(placeRowCard.index, placeRowCard.index - 1)
                             }
+
+                            StyledToolTip {
+                                text: qsTr("Move up")
+                                visible: upHover.containsMouse
+                            }
                         }
 
                         // Reorder Down
@@ -211,6 +221,11 @@ MouseArea {
                                 hoverEnabled: true
                                 cursorShape: placeRowCard.index < PlacesModel.count - 1 ? Qt.PointingHandCursor : undefined
                                 onClicked: PlacesModel.movePlace(placeRowCard.index, placeRowCard.index + 1)
+                            }
+
+                            StyledToolTip {
+                                text: qsTr("Move down")
+                                visible: downHover.containsMouse
                             }
                         }
 
@@ -238,6 +253,11 @@ MouseArea {
                                     root.editPlaceRequested(placeRowCard.index, placeRowCard.name, placeRowCard.path, placeRowCard.iconName, placeRowCard.isCustom);
                                 }
                             }
+
+                            StyledToolTip {
+                                text: qsTr("Edit place")
+                                visible: editHover.containsMouse
+                            }
                         }
 
                         // Delete / Unpin Button (for custom places)
@@ -261,6 +281,11 @@ MouseArea {
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: PlacesModel.removeBookmark(placeRowCard.index)
+                            }
+
+                            StyledToolTip {
+                                text: qsTr("Remove place")
+                                visible: delHover.containsMouse
                             }
                         }
                     }

--- a/qml/components/filedialog/HeaderBar.qml
+++ b/qml/components/filedialog/HeaderBar.qml
@@ -24,6 +24,7 @@ StyledRect {
             implicitHeight: upIcon.implicitHeight + Tokens.padding.small
 
             StateLayer {
+                id: upFolderHover
                 radius: Tokens.rounding.medium
                 disabled: root.dialog.cwd.length <= 1
                 onClicked: {
@@ -41,6 +42,11 @@ StyledRect {
                 text: "drive_folder_upload"
                 color: root.dialog.cwd.length <= 1 ? Colours.palette.m3outline : Colours.palette.m3onSurface
                 grade: 200
+            }
+
+            StyledToolTip {
+                text: qsTr("Go up")
+                visible: upFolderHover.containsMouse && !upFolderHover.disabled
             }
         }
 
@@ -140,6 +146,7 @@ StyledRect {
             implicitHeight: hiddenIcon.implicitHeight + Tokens.padding.small
 
             StateLayer {
+                id: hiddenHover
                 radius: Tokens.rounding.medium
                 onClicked: {
                     root.dialog.showHidden = !root.dialog.showHidden;
@@ -153,6 +160,11 @@ StyledRect {
                 text: root.dialog.showHidden ? "visibility" : "visibility_off"
                 color: root.dialog.showHidden ? Colours.palette.m3primary : Colours.palette.m3outline
                 fill: root.dialog.showHidden ? 1 : 0
+            }
+
+            StyledToolTip {
+                text: root.dialog.showHidden ? qsTr("Hide hidden files (Ctrl+H)") : qsTr("Show hidden files (Ctrl+H)")
+                visible: hiddenHover.containsMouse
             }
         }
     }

--- a/qml/components/navigation/NavigationBar.qml
+++ b/qml/components/navigation/NavigationBar.qml
@@ -69,6 +69,11 @@ StyledRect {
                     cursorShape: (root.activeTab && root.activeTab.canGoBack) ? Qt.PointingHandCursor : undefined
                     onClicked: if (root.activeTab && root.activeTab.canGoBack) root.activeTab.goBack()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Back (Alt+Left)")
+                    visible: backHover.containsMouse
+                }
             }
         }
 
@@ -96,6 +101,11 @@ StyledRect {
                     cursorShape: (root.activeTab && root.activeTab.canGoForward) ? Qt.PointingHandCursor : undefined
                     onClicked: if (root.activeTab && root.activeTab.canGoForward) root.activeTab.goForward()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Forward (Alt+Right)")
+                    visible: fwdHover.containsMouse
+                }
             }
         }
 
@@ -122,6 +132,11 @@ StyledRect {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: if (root.activeTab) root.activeTab.goUp()
+                }
+
+                StyledToolTip {
+                    text: qsTr("Up (Alt+Up)")
+                    visible: upHover.containsMouse
                 }
             }
         }
@@ -163,6 +178,11 @@ StyledRect {
                             }
                         }
                     }
+                }
+
+                StyledToolTip {
+                    text: parent.parent.isFav ? qsTr("Remove from Places") : qsTr("Add to Places")
+                    visible: favHover.containsMouse
                 }
             }
         }
@@ -304,13 +324,20 @@ StyledRect {
                     }
 
                     MouseArea {
+                        id: editPencilHover
                         anchors.fill: parent
+                        hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
                             root.isEditingPath = true;
                             pathInput.forceActiveFocus();
                             pathInput.selectAll();
                         }
+                    }
+
+                    StyledToolTip {
+                        text: qsTr("Edit location (Ctrl+L)")
+                        visible: editPencilHover.containsMouse
                     }
                 }
             }
@@ -375,9 +402,16 @@ StyledRect {
                     }
 
                     MouseArea {
+                        id: clearPathHover
                         anchors.fill: parent
+                        hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: pathInput.text = ""
+                    }
+
+                    StyledToolTip {
+                        text: qsTr("Clear")
+                        visible: clearPathHover.containsMouse
                     }
                 }
 
@@ -412,7 +446,9 @@ StyledRect {
                     }
 
                     MouseArea {
+                        id: acceptPathHover
                         anchors.fill: parent
+                        hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
                             if (root.activeTab && pathInput.text.trim().length > 0) {
@@ -424,6 +460,11 @@ StyledRect {
                             }
                             root.isEditingPath = false;
                         }
+                    }
+
+                    StyledToolTip {
+                        text: qsTr("Go to location")
+                        visible: acceptPathHover.containsMouse
                     }
                 }
             }
@@ -485,7 +526,9 @@ StyledRect {
                     }
 
                     MouseArea {
+                        id: closeSearchHover
                         anchors.fill: parent
+                        hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
                             searchInput.text = "";
@@ -496,6 +539,11 @@ StyledRect {
                                 splitContainer.focusActiveView();
                             }
                         }
+                    }
+
+                    StyledToolTip {
+                        text: qsTr("Close search (Esc)")
+                        visible: closeSearchHover.containsMouse
                     }
                 }
             }
@@ -533,6 +581,11 @@ StyledRect {
                             root.searchRequested("");
                         }
                     }
+                }
+
+                StyledToolTip {
+                    text: root.isSearching ? qsTr("Close search") : qsTr("Search (Ctrl+F)")
+                    visible: searchHover.containsMouse
                 }
             }
         }
@@ -577,6 +630,11 @@ StyledRect {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: FileOperations.emptyTrash()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Empty all items in Trash")
+                    visible: emptyHover.containsMouse
+                }
             }
         }
 
@@ -609,9 +667,16 @@ StyledRect {
                         }
 
                         MouseArea {
+                            id: gridHover
                             anchors.fill: parent
+                            hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
                             onClicked: if (root.activeTab) root.activeTab.viewMode = 0
+                        }
+
+                        StyledToolTip {
+                            text: qsTr("Icons view (Ctrl+1)")
+                            visible: gridHover.containsMouse
                         }
                     }
                 }
@@ -634,9 +699,16 @@ StyledRect {
                         }
 
                         MouseArea {
+                            id: listHover
                             anchors.fill: parent
+                            hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
                             onClicked: if (root.activeTab) root.activeTab.viewMode = 1
+                        }
+
+                        StyledToolTip {
+                            text: qsTr("Details view (Ctrl+2)")
+                            visible: listHover.containsMouse
                         }
                     }
                 }
@@ -659,9 +731,16 @@ StyledRect {
                         }
 
                         MouseArea {
+                            id: compactHover
                             anchors.fill: parent
+                            hoverEnabled: true
                             cursorShape: Qt.PointingHandCursor
                             onClicked: if (root.activeTab) root.activeTab.viewMode = 2
+                        }
+
+                        StyledToolTip {
+                            text: qsTr("Compact view (Ctrl+3)")
+                            visible: compactHover.containsMouse
                         }
                     }
                 }
@@ -692,6 +771,11 @@ StyledRect {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: root.toggleTerminal()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Open Terminal (F4)")
+                    visible: termHover.containsMouse
+                }
             }
         }
 
@@ -718,6 +802,11 @@ StyledRect {
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: root.togglePreview()
+                }
+
+                StyledToolTip {
+                    text: qsTr("Information panel (F11)")
+                    visible: infoHover.containsMouse
                 }
             }
         }

--- a/qml/components/panels/PlacesSidebar.qml
+++ b/qml/components/panels/PlacesSidebar.qml
@@ -60,6 +60,11 @@ StyledRect {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: root.managePlacesRequested()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Configure Places")
+                    visible: cfgHover.containsMouse
+                }
             }
         }
 

--- a/qml/components/statusbar/StatusBar.qml
+++ b/qml/components/statusbar/StatusBar.qml
@@ -89,6 +89,12 @@ StyledRect {
                     cursorShape: Qt.PointingHandCursor
                     onClicked: root.gitRequested()
                 }
+
+                StyledToolTip {
+                    text: qsTr("Git branch: %1").arg(GitManager.branchName)
+                    visible: gitChipHover.containsMouse
+                    y: -height - Tokens.padding.extraSmall
+                }
             }
         }
 
@@ -96,18 +102,33 @@ StyledRect {
         RowLayout {
             spacing: Tokens.spacing.extraSmall
 
-            MaterialIcon {
-                text: "photo_size_select_small"
-                fontStyle: Tokens.font.icon.small
-                color: zoomSlider.value <= 0.1 ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            Item {
+                implicitWidth: zoomSmallIcon.implicitWidth
+                implicitHeight: zoomSmallIcon.implicitHeight
+
+                MaterialIcon {
+                    id: zoomSmallIcon
+                    anchors.centerIn: parent
+                    text: "photo_size_select_small"
+                    fontStyle: Tokens.font.icon.small
+                    color: zoomSlider.value <= 0.1 ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                }
 
                 MouseArea {
+                    id: zoomSmallHover
                     anchors.fill: parent
+                    hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: {
                         zoomSlider.value = 0.0;
                         root.zoomChanged(48);
                     }
+                }
+
+                StyledToolTip {
+                    text: qsTr("Small icons")
+                    visible: zoomSmallHover.containsMouse
+                    y: -height - Tokens.padding.extraSmall
                 }
             }
 
@@ -125,18 +146,33 @@ StyledRect {
                 }
             }
 
-            MaterialIcon {
-                text: "photo_size_select_large"
-                fontStyle: Tokens.font.icon.small
-                color: zoomSlider.value >= 0.9 ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            Item {
+                implicitWidth: zoomLargeIcon.implicitWidth
+                implicitHeight: zoomLargeIcon.implicitHeight
+
+                MaterialIcon {
+                    id: zoomLargeIcon
+                    anchors.centerIn: parent
+                    text: "photo_size_select_large"
+                    fontStyle: Tokens.font.icon.small
+                    color: zoomSlider.value >= 0.9 ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                }
 
                 MouseArea {
+                    id: zoomLargeHover
                     anchors.fill: parent
+                    hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
                     onClicked: {
                         zoomSlider.value = 1.0;
                         root.zoomChanged(180);
                     }
+                }
+
+                StyledToolTip {
+                    text: qsTr("Large icons")
+                    visible: zoomLargeHover.containsMouse
+                    y: -height - Tokens.padding.extraSmall
                 }
             }
         }
@@ -171,6 +207,12 @@ StyledRect {
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
                 onClicked: root.operationsRequested()
+            }
+
+            StyledToolTip {
+                text: FileOperations.progress.running ? qsTr("Operations in progress") : qsTr("Operations history")
+                visible: opsHover.containsMouse
+                y: -height - Tokens.padding.extraSmall
             }
         }
     }

--- a/qml/components/tabs/TabBar.qml
+++ b/qml/components/tabs/TabBar.qml
@@ -251,6 +251,11 @@ StyledRect {
                                         }
                                     }
                                 }
+
+                                StyledToolTip {
+                                    text: tabItem.isSplit ? qsTr("Close pane") : qsTr("Close tab (Ctrl+W)")
+                                    visible: closeHover1.containsMouse
+                                }
                             }
                         }
 
@@ -320,6 +325,11 @@ StyledRect {
                                         TabManager.closeSplitPane(tabItem.index, 1);
                                     }
                                 }
+
+                                StyledToolTip {
+                                    text: qsTr("Close pane")
+                                    visible: closeHover2.containsMouse
+                                }
                             }
                         }
                     }
@@ -366,6 +376,11 @@ StyledRect {
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: TabManager.newTab()
+                    }
+
+                    StyledToolTip {
+                        text: qsTr("New tab (Ctrl+T)")
+                        visible: addHover.containsMouse
                     }
                 }
             }

--- a/qml/components/tabs/TabBar.qml
+++ b/qml/components/tabs/TabBar.qml
@@ -211,7 +211,7 @@ StyledRect {
                                     ? (tabItem.isSplit && tabItem.activePane === 1 ? Colours.palette.m3onSurfaceVariant : Colours.palette.m3onSurface)
                                     : Colours.palette.m3onSurfaceVariant
                                 font: tabItem.selected && (!tabItem.isSplit || tabItem.activePane === 0)
-                                    ? Tokens.font.builders.body.small.weight(Font.DemiBold).build()
+                                    ? Tokens.font.body.builders.small.weight(Font.DemiBold).build()
                                     : Tokens.font.body.small
                                 elide: Text.ElideRight
                             }
@@ -290,7 +290,7 @@ StyledRect {
                                     ? (tabItem.activePane === 1 ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant)
                                     : Colours.palette.m3onSurfaceVariant
                                 font: tabItem.selected && tabItem.activePane === 1
-                                    ? Tokens.font.builders.body.small.weight(Font.DemiBold).build()
+                                    ? Tokens.font.body.builders.small.weight(Font.DemiBold).build()
                                     : Tokens.font.body.small
                                 elide: Text.ElideRight
                             }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -485,7 +485,13 @@ ApplicationWindow {
 
         Shortcut {
             sequence: "Ctrl+W"
-            onActivated: TabManager.closeTab(TabManager.currentIndex)
+            onActivated: {
+                if (TabManager.currentTab && TabManager.currentTab.isSplit) {
+                    TabManager.closeSplitPane(TabManager.currentIndex, TabManager.currentTab.activePane);
+                } else {
+                    TabManager.closeTab(TabManager.currentIndex);
+                }
+            }
         }
 
         Shortcut {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -558,7 +558,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "F2"
+            sequences: ["F2", "Shift+F2"]
             onActivated: {
                 let sel = splitContainer.currentSelectedPath;
                 if (sel && sel.length > 0) {
@@ -648,12 +648,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "Ctrl+F"
-            onActivated: navBar.openSearch()
-        }
-
-        Shortcut {
-            sequence: "F9"
+            sequences: ["Ctrl+F", "F9", "Shift+F9"]
             onActivated: navBar.openSearch()
         }
 
@@ -668,7 +663,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "F3"
+            sequences: ["F3", "Shift+F3"]
             onActivated: {
                 if (TabManager.currentTab) {
                     TabManager.currentTab.isSplit = !TabManager.currentTab.isSplit;
@@ -680,7 +675,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "F4"
+            sequences: ["F4", "Shift+F4", "Ctrl+Alt+T", "Ctrl+`"]
             onActivated: {
                 if (TabManager.currentTab) {
                     AppIntegration.openInTerminal(window.getActiveDirectory());
@@ -689,7 +684,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "F5"
+            sequences: ["F5", "Shift+F5", "Ctrl+R"]
             onActivated: {
                 if (splitContainer.activeModel) {
                     splitContainer.activeModel.refresh();
@@ -698,16 +693,7 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "Ctrl+R"
-            onActivated: {
-                if (splitContainer.activeModel) {
-                    splitContainer.activeModel.refresh();
-                }
-            }
-        }
-
-        Shortcut {
-            sequence: "F10"
+            sequences: ["F10", "Shift+F10"]
             onActivated: {
                 newItemModal.title = qsTr("Create New Folder");
                 newItemModal.icon = "create_new_folder";
@@ -717,12 +703,12 @@ ApplicationWindow {
         }
 
         Shortcut {
-            sequence: "F1"
+            sequences: ["F1", "Shift+F1", "Alt+P"]
             onActivated: previewPanel.expanded = !previewPanel.expanded
         }
 
         Shortcut {
-            sequence: "F11"
+            sequences: ["F11", "Shift+F11"]
             onActivated: {
                 if (window.visibility === Window.FullScreen) {
                     window.visibility = Window.Windowed;

--- a/src/controllers/tabmanager.cpp
+++ b/src/controllers/tabmanager.cpp
@@ -347,6 +347,7 @@ void TabManager::closeSplitPane(int tabIndex, int paneIndex) {
             tab->setCurrentPath(tab->splitPath());
         }
         tab->setIsSplit(false);
+        tab->setActivePane(0);
     }
 }
 


### PR DESCRIPTION
- Created a reusable `StyledToolTip` component adhering to Material 3 design tokens and theme palettes.
- Added hover tooltips with keyboard shortcut hints to all action and navigation icon buttons across the app.
- Support Shift+F[x], Ctrl+Alt+T, and Alt+P because laptop keyboards default function keys to hardware/media controls, preventing standalone F-keys from triggering unless Fn-Lock is engaged..