### PR TITLE
fix: percent-encode Path in .trashinfo files

### DIFF
--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -458,7 +458,9 @@ void FileOperations::moveToTrash(const QStringList& paths) {
             QFile info(infoFile);
             if (info.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QString deletionDate = QDateTime::currentDateTime().toString(Qt::ISODate);
-                QString content = QString("[Trash Info]\nPath=%1\nDeletionDate=%2\n").arg(fi.absoluteFilePath(), deletionDate);
+                const QString encodedPath =
+                    QString::fromLatin1(QUrl::toPercentEncoding(fi.absoluteFilePath(), "/"));
+                QString content = QString("[Trash Info]\nPath=%1\nDeletionDate=%2\n").arg(encodedPath, deletionDate);
                 info.write(content.toUtf8());
                 info.close();
             }
@@ -511,7 +513,7 @@ void FileOperations::restoreFromTrash(const QString& targetPath) {
     while (!file.atEnd()) {
         QString line = QString::fromUtf8(file.readLine()).trimmed();
         if (line.startsWith("Path=")) {
-            origPath = line.mid(5);
+            origPath = QUrl::fromPercentEncoding(line.mid(5).toUtf8());
             break;
         }
     }

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -4,6 +4,7 @@
 #include <QCollator>
 #include <QDir>
 #include <QDirIterator>
+#include <QUrl>
 #include <QFileInfo>
 #include <QImageReader>
 #include <QMimeDatabase>
@@ -222,7 +223,7 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
             while (!infoFile.atEnd()) {
                 QString line = QString::fromUtf8(infoFile.readLine()).trimmed();
                 if (line.startsWith("Path=")) {
-                    d.originalPath = line.mid(5);
+                    d.originalPath = QUrl::fromPercentEncoding(line.mid(5).toUtf8());
                 } else if (line.startsWith("DeletionDate=")) {
                     QString dStr = line.mid(13);
                     QDateTime dt = QDateTime::fromString(dStr, Qt::ISODate);


### PR DESCRIPTION
## Problem

The [freedesktop.org trash specification](https://specifications.freedesktop.org/trash-spec/trashspec-latest.html) requires the `Path` key in `.trashinfo` files to be percent-encoded, leaving only `/` literal. Prism writes the raw path instead.

This breaks interoperability in both directions for any file whose name contains spaces or non-ASCII characters:

- Files trashed by Prism cannot be restored correctly by other file managers, since they percent-decode the value and mangle it.
- Files trashed by other file managers cannot be restored by Prism, since it treats `%20` and friends as literal text.

The trash view is affected too: it shows the raw value, so an entry trashed by e.g. Nautilus displays as `Eximora%20Firmendokumente.zip`.

## Change

Encode on write, decode on read. Three call sites:

- `FileOperations::moveToTrash` — percent-encode when writing `Path`
- `FileOperations::restoreFromTrash` — decode before resolving the destination
- `createRawDataFromInfo` — decode for the original path shown in the trash view

Decoding is backward compatible: paths previously written raw by Prism contain no percent sequences, so decoding them is a no-op.

## Verification

Trashing a file named `Ümlaut Test Datei #1.txt` from `~/Dokumente/prism-test` now produces:

```
[Trash Info]
Path=/home/vladi/Dokumente/prism-test/%C3%9Cmlaut%20Test%20Datei%20%231.txt
DeletionDate=2026-08-22T20:29:50
```

glib resolves it correctly, which is the behaviour the spec is there to guarantee:

```
$ gio trash --list
trash:///%C3%9Cmlaut%20Test%20Datei%20%231.txt	/home/vladi/Dokumente/prism-test/Ümlaut Test Datei #1.txt
```

A file with no special characters is written unchanged, so existing entries are unaffected.
