### PR TITLE
feat: confirm before permanently deleting files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ qt_add_qml_module(prism_app
         qml/components/dialogs/GitModal.qml
         qml/components/dialogs/CompressModal.qml
         qml/components/dialogs/OperationsModal.qml
+        qml/components/dialogs/ConfirmDeleteModal.qml
         qml/components/dialogs/VectorBloomOverlay.qml
         qml/components/dialogs/RunnerGameModal.qml
         qml/components/media/ImageViewer.qml

--- a/qml/components/dialogs/ConfirmDeleteModal.qml
+++ b/qml/components/dialogs/ConfirmDeleteModal.qml
@@ -1,0 +1,167 @@
+import QtQuick
+import QtQuick.Layouts
+import "../"
+import prism
+
+MouseArea {
+    id: root
+
+    property bool expanded: false
+    property var targetPaths: []
+
+    signal confirmed(var paths)
+
+    anchors.fill: parent
+    visible: opacity > 0.001
+    enabled: expanded
+    hoverEnabled: expanded
+    cursorShape: expanded ? Qt.ArrowCursor : undefined
+    z: 100
+
+    opacity: expanded ? 1.0 : 0.0
+    Behavior on opacity {
+        Anim {
+            type: Anim.FastEffects
+        }
+    }
+
+    onClicked: root.expanded = false
+    onWheel: wheel => wheel.accepted = true
+
+    Keys.onEscapePressed: root.expanded = false
+
+    onExpandedChanged: {
+        if (expanded) {
+            root.forceActiveFocus();
+        } else {
+            root.targetPaths = [];
+            if (typeof splitContainer !== "undefined" && splitContainer) {
+                splitContainer.focusActiveView();
+            }
+        }
+    }
+
+    function accept(): void {
+        const paths = root.targetPaths;
+        root.expanded = false;
+        if (paths.length > 0) {
+            root.confirmed(paths);
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.alpha(Colours.palette.m3scrim, 0.4)
+    }
+
+    StyledRect {
+        id: modalCard
+
+        anchors.centerIn: parent
+        width: Math.min(parent.width - 48, 440)
+        height: Math.min(parent.height - 32, modalCol.implicitHeight + Tokens.padding.large * 2)
+        implicitWidth: Math.min(parent.width - 48, 440)
+        implicitHeight: modalCol.implicitHeight + Tokens.padding.large * 2
+
+        radius: Tokens.rounding.large
+        color: Colours.palette.m3surfaceContainerHigh
+
+        scale: root.expanded ? 1.0 : 0.94
+
+        Behavior on scale {
+            Anim {
+                type: Anim.FastEffects
+                easing: Tokens.anim.standard
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
+        }
+
+        ColumnLayout {
+            id: modalCol
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.large
+            spacing: Tokens.spacing.medium
+
+            RowLayout {
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: "delete_forever"
+                    color: Colours.palette.m3error
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Delete permanently")
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.title.medium
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: root.targetPaths.length === 1 ? qsTr("\"%1\" will be deleted permanently. This cannot be undone.").arg(root.targetPaths.length > 0 ? root.targetPaths[0].split("/").pop() : "") : qsTr("%n items will be deleted permanently. This cannot be undone.", "", root.targetPaths.length)
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.body.medium
+                wrapMode: Text.WordWrap
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                StyledRect {
+                    implicitWidth: 70
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    color: "transparent"
+
+                    StateLayer {
+                        color: Colours.palette.m3onSurface
+                        onClicked: root.expanded = false
+                    }
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: qsTr("Cancel")
+                        color: Colours.palette.m3primary
+                        font: Tokens.font.label.large
+                    }
+                }
+
+                StyledRect {
+                    implicitWidth: 80
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    color: Colours.palette.m3error
+
+                    StateLayer {
+                        color: Colours.palette.m3onError
+                        onClicked: root.accept()
+                    }
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: qsTr("Delete")
+                        color: Colours.palette.m3onError
+                        font: Tokens.font.label.large
+                    }
+                }
+            }
+        }
+    }
+
+    Keys.onReturnPressed: root.accept()
+    Keys.onEnterPressed: root.accept()
+}

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -303,6 +303,64 @@ MouseArea {
                                 }
                             }
 
+                            // Confirm permanent delete toggle card
+                            StyledRect {
+                                Layout.fillWidth: true
+                                implicitHeight: 56
+                                radius: Tokens.rounding.large
+                                color: confirmDelHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Tokens.padding.medium
+                                    anchors.rightMargin: Tokens.padding.medium
+                                    spacing: Tokens.spacing.medium
+
+                                    MaterialIcon {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        text: "delete_forever"
+                                        color: AppController.confirmPermanentDelete ? Colours.palette.m3primary : Colours.palette.m3outline
+                                        fontStyle: Tokens.font.icon.medium
+                                    }
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        Layout.alignment: Qt.AlignVCenter
+                                        spacing: 2
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Confirm Permanent Deletion")
+                                            color: Colours.palette.m3onSurface
+                                            font: Tokens.font.body.small
+                                            elide: Text.ElideRight
+                                        }
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Ask before deleting files without using the trash (Shift+Delete)")
+                                            color: Colours.palette.m3onSurfaceVariant
+                                            font: Tokens.font.label.small
+                                            elide: Text.ElideRight
+                                        }
+                                    }
+
+                                    StyledCheckBox {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        checked: AppController.confirmPermanentDelete
+                                        onToggled: val => AppController.confirmPermanentDelete = val
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: confirmDelHover
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: AppController.confirmPermanentDelete = !AppController.confirmPermanentDelete
+                                }
+                            }
+
                             // Single-click toggle card
                             StyledRect {
                                 Layout.fillWidth: true

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -41,6 +41,16 @@ ApplicationWindow {
             : TabManager.currentTab.currentPath;
     }
 
+    function requestPermanentDelete(paths) {
+        if (!paths || paths.length === 0) return;
+        if (AppController.confirmPermanentDelete) {
+            confirmDeleteModal.targetPaths = paths;
+            confirmDeleteModal.expanded = true;
+        } else {
+            FileOperations.deletePermanently(paths);
+        }
+    }
+
     function setActiveDirectory(path) {
         if (!TabManager.currentTab) return;
         let expanded = FileUtils.expandPath(path);
@@ -327,7 +337,7 @@ ApplicationWindow {
                 } else if (action === "trash" && item) {
                     FileOperations.moveToTrash(targetPaths);
                 } else if (action === "delete" && item) {
-                    FileOperations.deletePermanently(targetPaths);
+                    window.requestPermanentDelete(targetPaths);
                 } else if (action === "newFolder") {
                     newItemModal.title = qsTr("Create New Folder");
                     newItemModal.icon = "create_new_folder";
@@ -398,6 +408,12 @@ ApplicationWindow {
         // Operations & Background Activity Modal
         OperationsModal {
             id: operationsModal
+        }
+
+        // Permanent Delete Confirmation Modal
+        ConfirmDeleteModal {
+            id: confirmDeleteModal
+            onConfirmed: paths => FileOperations.deletePermanently(paths)
         }
 
         // Places & Devices Management Modal
@@ -653,7 +669,7 @@ ApplicationWindow {
             context: Qt.ApplicationShortcut
             onActivated: {
                 let paths = splitContainer.selectedPaths.length > 0 ? splitContainer.selectedPaths : (splitContainer.currentSelectedPath ? [splitContainer.currentSelectedPath] : []);
-                if (paths.length > 0) FileOperations.deletePermanently(paths);
+                if (paths.length > 0) window.requestPermanentDelete(paths);
             }
         }
 

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -12,6 +12,7 @@ AppController::AppController(QObject* parent)
     QSettings legacy2("Caelestia", "Prism");
     m_showHidden = settings.value("session/showHidden", legacy1.value("session/showHidden", legacy2.value("session/showHidden", false))).toBool();
     m_singleClick = settings.value("session/singleClick", legacy1.value("session/singleClick", legacy2.value("session/singleClick", false))).toBool();
+    m_confirmPermanentDelete = settings.value("session/confirmPermanentDelete", true).toBool();
     m_defaultStartupDirectory = settings.value("preferences/startupDirectory", "home").toString();
     m_defaultViewMode = settings.value("preferences/defaultViewMode", 0).toInt();
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
@@ -57,6 +58,15 @@ void AppController::setDirectoryOnly(bool dirOnly) {
     if (m_directoryOnly != dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
+    }
+}
+
+void AppController::setConfirmPermanentDelete(bool confirm) {
+    if (m_confirmPermanentDelete != confirm) {
+        m_confirmPermanentDelete = confirm;
+        QSettings settings("prism", "prism");
+        settings.setValue("session/confirmPermanentDelete", confirm);
+        emit confirmPermanentDeleteChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -19,6 +19,7 @@ class AppController : public QObject {
     Q_PROPERTY(QStringList filters READ filters WRITE setFilters NOTIFY filtersChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+    Q_PROPERTY(bool confirmPermanentDelete READ confirmPermanentDelete WRITE setConfirmPermanentDelete NOTIFY confirmPermanentDeleteChanged)
     Q_PROPERTY(bool singleClick READ singleClick WRITE setSingleClick NOTIFY singleClickChanged)
     Q_PROPERTY(QString defaultStartupDirectory READ defaultStartupDirectory WRITE setDefaultStartupDirectory NOTIFY defaultStartupDirectoryChanged)
     Q_PROPERTY(int defaultViewMode READ defaultViewMode WRITE setDefaultViewMode NOTIFY defaultViewModeChanged)
@@ -53,6 +54,8 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    [[nodiscard]] bool confirmPermanentDelete() const { return m_confirmPermanentDelete; }
+    void setConfirmPermanentDelete(bool confirm);
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }
@@ -88,6 +91,7 @@ signals:
     void filtersChanged();
     void directoryOnlyChanged();
     void showHiddenChanged();
+    void confirmPermanentDeleteChanged();
     void singleClickChanged();
     void defaultStartupDirectoryChanged();
     void defaultViewModeChanged();
@@ -107,6 +111,7 @@ private:
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
     bool m_showHidden = false;
+    bool m_confirmPermanentDelete = true;
     bool m_singleClick = false;
     QString m_defaultStartupDirectory = "home";
     int m_defaultViewMode = 0; // Grid, Details, Compact


### PR DESCRIPTION
## Problem

Permanent deletion is irreversible and currently happens without any prompt. Pressing `Shift+Delete`, or choosing **Delete Permanently** in the trash context menu, removes the selection immediately.

Moving items to the trash is reversible, so it should stay unprompted — this only covers the destructive path.

## Change

A confirmation dialog in front of `FileOperations.deletePermanently`, wired into both call sites in `main.qml` through a single `requestPermanentDelete()` helper.

`ConfirmDeleteModal.qml` follows the structure of `NewItemModal`: same scrim, card geometry, `Anim` transitions and button metrics. The only deviation is the confirm button, which uses `m3error` / `m3onError` instead of `m3primary`. Those roles are already used for destructive actions in `PlacesManageModal`.

The message names the file for a single selection and falls back to a plural item count for multiple. `Escape` cancels, `Enter` confirms.

## Preference

Added under Preferences as **Confirm Permanent Deletion**, matching the existing toggle cards. Stored as `session/confirmPermanentDelete` via `AppController`, enabled by default. With it off, the previous behaviour is restored exactly.

## Verification

Three paths checked against the filesystem:

| Action | Result |
|---|---|
| `Shift+Delete`, confirmed | file gone, not present in the trash |
| `Shift+Delete`, cancelled | file untouched |
| `Delete` | moved to trash, no prompt |
