### PR TITLE
feat: make the date format configurable

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -531,6 +531,75 @@ MouseArea {
                             Item { implicitHeight: 4 }
 
                             StyledText {
+                                text: qsTr("Date Format")
+                                color: Colours.palette.m3primary
+                                font: Tokens.font.label.large
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Tokens.spacing.small
+
+                                Repeater {
+                                    model: [
+                                        { mode: 1, label: qsTr("ISO"), icon: "calendar_month" },
+                                        { mode: 0, label: qsTr("Short"), icon: "schedule" },
+                                        { mode: 2, label: qsTr("Long"), icon: "event_note" }
+                                    ]
+
+                                    StyledRect {
+                                        id: dateCard
+                                        required property int index
+                                        required property var modelData
+
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.dateFormat === dateCard.modelData.mode
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (dateHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        RowLayout {
+                                            anchors.centerIn: parent
+                                            spacing: 6
+
+                                            MaterialIcon {
+                                                text: dateCard.modelData.icon
+                                                color: dateCard.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                                                fontStyle: Tokens.font.icon.small
+                                            }
+
+                                            StyledText {
+                                                text: dateCard.modelData.label
+                                                color: dateCard.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            id: dateHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.dateFormat = dateCard.modelData.mode
+                                        }
+                                    }
+                                }
+                            }
+
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: FileUtils.formatDateTime(new Date(), AppController.dateFormat)
+                                color: Colours.palette.m3onSurfaceVariant
+                                font: Tokens.font.label.small
+                                elide: Text.ElideRight
+                            }
+
+                            Item { implicitHeight: 4 }
+
+                            StyledText {
                                 text: qsTr("Places Sidebar Icon Size")
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -39,6 +39,14 @@ StyledRect {
     }
     readonly property var activeModel: (isSplit && activePane === 1) ? splitModel : mainModel
 
+    Connections {
+        target: AppController
+        function onDateFormatChanged() {
+            if (mainModel) mainModel.refresh();
+            if (splitModel) splitModel.refresh();
+        }
+    }
+
     signal itemContextMenu(var item, real mouseX, real mouseY)
     signal blankContextMenu(real mouseX, real mouseY)
     signal filesDropped(var sources, string destDir, real mouseX, real mouseY)

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -1,4 +1,5 @@
 #include "appcontroller.hpp"
+#include "fileutils.hpp"
 #include "iconprovider.hpp"
 #include <QSettings>
 #include <iostream>
@@ -18,6 +19,8 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+    m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
+    FileUtils::setDateFormat(m_dateFormat);
 }
 
 AppController* AppController::instance() {
@@ -57,6 +60,16 @@ void AppController::setDirectoryOnly(bool dirOnly) {
     if (m_directoryOnly != dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
+    }
+}
+
+void AppController::setDateFormat(int format) {
+    if (m_dateFormat != format) {
+        m_dateFormat = format;
+        FileUtils::setDateFormat(format);
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/dateFormat", format);
+        emit dateFormatChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -19,6 +19,7 @@ class AppController : public QObject {
     Q_PROPERTY(QStringList filters READ filters WRITE setFilters NOTIFY filtersChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+    Q_PROPERTY(int dateFormat READ dateFormat WRITE setDateFormat NOTIFY dateFormatChanged)
     Q_PROPERTY(bool singleClick READ singleClick WRITE setSingleClick NOTIFY singleClickChanged)
     Q_PROPERTY(QString defaultStartupDirectory READ defaultStartupDirectory WRITE setDefaultStartupDirectory NOTIFY defaultStartupDirectoryChanged)
     Q_PROPERTY(int defaultViewMode READ defaultViewMode WRITE setDefaultViewMode NOTIFY defaultViewModeChanged)
@@ -53,6 +54,8 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    [[nodiscard]] int dateFormat() const { return m_dateFormat; }
+    void setDateFormat(int format);
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }
@@ -88,6 +91,7 @@ signals:
     void filtersChanged();
     void directoryOnlyChanged();
     void showHiddenChanged();
+    void dateFormatChanged();
     void singleClickChanged();
     void defaultStartupDirectoryChanged();
     void defaultViewModeChanged();
@@ -107,6 +111,7 @@ private:
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
     bool m_showHidden = false;
+    int m_dateFormat = 1;
     bool m_singleClick = false;
     QString m_defaultStartupDirectory = "home";
     int m_defaultViewMode = 0; // Grid, Details, Compact

--- a/src/core/filemetadata.cpp
+++ b/src/core/filemetadata.cpp
@@ -1,5 +1,6 @@
 #include "filemetadata.hpp"
 #include "fileutils.hpp"
+#include "fileutils.hpp"
 
 #include <QCryptographicHash>
 #include <QtConcurrent>
@@ -129,8 +130,8 @@ void FileMetadata::reload() {
     m_owner = fi.owner();
     m_group = fi.group();
 
-    m_formattedCreated = fi.birthTime().toString("yyyy-MM-dd hh:mm");
-    m_formattedModified = fi.lastModified().toString("yyyy-MM-dd hh:mm");
+    m_formattedCreated = FileUtils::formatDateTime(fi.birthTime());
+    m_formattedModified = FileUtils::formatDateTime(fi.lastModified());
     m_formattedAccessed = fi.lastRead().toString("yyyy-MM-dd hh:mm");
 
     if (m_isImage) {

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -1,4 +1,8 @@
 #include "fileutils.hpp"
+
+#include <QDateTime>
+#include <QLocale>
+#include <atomic>
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeDatabase>
@@ -36,6 +40,35 @@ QString FileUtils::music() const {
 
 QString FileUtils::desktop() const {
     return QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+}
+
+namespace {
+std::atomic<int> g_dateFormat{FileUtils::Iso};
+}
+
+void FileUtils::setDateFormat(int format) {
+    g_dateFormat.store(format, std::memory_order_relaxed);
+}
+
+int FileUtils::dateFormat() {
+    return g_dateFormat.load(std::memory_order_relaxed);
+}
+
+QString FileUtils::formatDateTime(const QDateTime& dt, int format) {
+    if (!dt.isValid())
+        return {};
+
+    if (format < 0)
+        format = g_dateFormat.load(std::memory_order_relaxed);
+
+    switch (format) {
+    case SystemLocale:
+        return QLocale::system().toString(dt, QLocale::ShortFormat);
+    case LongLocale:
+        return QLocale::system().toString(dt, QLocale::LongFormat);
+    default:
+        return dt.toString(QStringLiteral("yyyy-MM-dd hh:mm"));
+    }
 }
 
 QString FileUtils::formatSize(qint64 bytes) {

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDateTime>
 #include <QObject>
 #include <QString>
 #include <QUrl>
@@ -31,7 +32,17 @@ public:
     [[nodiscard]] QString music() const;
     [[nodiscard]] QString desktop() const;
 
+    enum DateFormat {
+        SystemLocale = 0,
+        Iso = 1,
+        LongLocale = 2
+    };
+    Q_ENUM(DateFormat)
+
     Q_INVOKABLE static QString formatSize(qint64 bytes);
+    Q_INVOKABLE static QString formatDateTime(const QDateTime& dt, int format = -1);
+    static void setDateFormat(int format);
+    static int dateFormat();
     Q_INVOKABLE static QString shortenHome(const QString& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
     Q_INVOKABLE static QString baseName(const QString& path);

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -183,7 +183,7 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
     d.isWritable = fi.isWritable();
     d.isReadOnly = !d.isWritable;
     d.lastModified = fi.lastModified();
-    d.formattedDate = d.lastModified.toString("yyyy-MM-dd hh:mm");
+    d.formattedDate = prism::core::FileUtils::formatDateTime(d.lastModified);
     d.owner = fi.owner();
     d.group = fi.group();
 
@@ -227,7 +227,7 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
                     QString dStr = line.mid(13);
                     QDateTime dt = QDateTime::fromString(dStr, Qt::ISODate);
                     if (dt.isValid()) {
-                        d.deletionTime = dt.toString("M/d/yy 'at' h:mm AP");
+                        d.deletionTime = prism::core::FileUtils::formatDateTime(dt);
                     } else {
                         d.deletionTime = dStr;
                     }


### PR DESCRIPTION
## Problem

Dates are formatted with hardcoded patterns in four places, and they do not agree with each other:

| Location | Pattern |
|---|---|
| `filesystemmodel.cpp` — file listings | `yyyy-MM-dd hh:mm` |
| `filemetadata.cpp` — created / modified | `yyyy-MM-dd hh:mm` |
| `filesystemmodel.cpp` — trash deletion time | `M/d/yy 'at' h:mm AP` |

So the trash view shows something like `8/19/26 at 4:35 PM` while every other view shows `2026-08-19 16:35`, in the same window. The trash pattern also embeds an untranslated English word and a 12-hour clock regardless of locale.

## Change

All four call sites now go through `FileUtils::formatDateTime`, and a **Date Format** preference selects between three presets:

- **ISO** — `yyyy-MM-dd hh:mm`, locale independent, the existing behaviour and the default
- **Short** — `QLocale::system()` short format
- **Long** — `QLocale::system()` long format

Since the default is unchanged, existing installs see no difference until they opt in.

The preference sits in View & Sorting using the same card row as Default View Mode, with a live preview of the current time underneath so the locale-dependent presets are not a guess.

## Implementation notes

The selected format is held in a `std::atomic<int>` rather than read from `QSettings` per entry, because `createRawDataFromInfo` runs on worker threads during directory scans.

`formatDateTime` takes an optional explicit format so the preview can render a specific preset without touching the stored setting.

Open views refresh through a `Connections` block on `AppController::dateFormatChanged`, so switching the format updates the current listing without navigating away.
