### PR TITLE
fix: keep the icon size slider bound to the zoom level

### DIFF
--- a/qml/components/statusbar/StatusBar.qml
+++ b/qml/components/statusbar/StatusBar.qml
@@ -119,10 +119,7 @@ StyledRect {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        zoomSlider.value = 0.0;
-                        root.zoomChanged(48);
-                    }
+                    onClicked: root.zoomChanged(48)
                 }
 
                 StyledToolTip {
@@ -163,10 +160,7 @@ StyledRect {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        zoomSlider.value = 1.0;
-                        root.zoomChanged(180);
-                    }
+                    onClicked: root.zoomChanged(180)
                 }
 
                 StyledToolTip {


### PR DESCRIPTION
## Problem

The icon size slider in the status bar stops responding after clicking either of the two size buttons next to it. The handle pins to the end that was clicked and no longer follows the zoom level.

`value` is bound to the zoom level:

```qml
value: (root.zoomLevel - 48) / (180 - 48)
```

but the buttons assign to it imperatively:

```qml
onClicked: {
    zoomSlider.value = 0.0;
    root.zoomChanged(48);
}
```

In QML an imperative assignment to a bound property drops the binding permanently, so from that point on `value` no longer tracks `zoomLevel`.

## Change

Remove both assignments and keep only the signal. `zoomChanged` sets `window.zoomLevel`, which `StatusBar.zoomLevel` is bound to, which `value` derives from — the handle ends up at exactly the same position, and the binding survives.

`StyledSlider` never writes to `value` itself, it only emits `interaction`, so dragging was never the problem.

Net change is six lines removed.
