### PR TITLE
feat: scale icons with the zoom level in compact and details views

### DIFF
--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -10,6 +10,8 @@ Item {
 
     required property var model
     required property var activeTab
+    property real zoomSize: 80
+    readonly property int iconSize: Math.max(16, Math.min(64, Math.round(20 * zoomSize / 80)))
     property int paneIndex: 0
     property int currentIndex: gridView.currentIndex
     readonly property var currentItem: {
@@ -119,8 +121,8 @@ Item {
 
         anchors.fill: parent
         anchors.margins: Tokens.padding.small
-        cellWidth: 220
-        cellHeight: 38
+        cellWidth: Math.max(220, 200 + root.iconSize)
+        cellHeight: root.iconSize + 18
         flow: GridView.FlowTopToBottom
         clip: true
         focus: true
@@ -483,12 +485,12 @@ Item {
                     spacing: Tokens.spacing.small
 
                     Item {
-                        implicitWidth: 20
-                        implicitHeight: 20
+                        implicitWidth: root.iconSize
+                        implicitHeight: root.iconSize
 
                         CachingIconImage {
                             anchors.fill: parent
-                            implicitSize: 20
+                            implicitSize: root.iconSize
 
                             source: {
                                 const file = compDelegate.modelData;

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -10,6 +10,9 @@ Item {
 
     required property var model
     required property var activeTab
+    property real zoomSize: 80
+    readonly property int iconSize: Math.max(16, Math.min(64, Math.round(22 * zoomSize / 80)))
+    readonly property int rowHeight: Math.max(36, iconSize + 14)
     property int paneIndex: 0
     property int currentIndex: listView.currentIndex
     readonly property var currentItem: {
@@ -518,7 +521,7 @@ Item {
                 readonly property bool isHidden: rowItem.modelData ? (rowItem.modelData.isHidden || rowItem.modelData.name.startsWith('.')) : false
 
                 width: listView.width
-                implicitHeight: 36
+                implicitHeight: root.rowHeight
 
                 radius: Tokens.rounding.small
                 color: folderDropArea.containsDrag
@@ -690,13 +693,13 @@ Item {
                         spacing: Tokens.spacing.small
 
                         Item {
-                            implicitWidth: 22
-                            implicitHeight: 22
+                            implicitWidth: root.iconSize
+                            implicitHeight: root.iconSize
 
                             CachingIconImage {
                                 id: rowIcon
                                 anchors.fill: parent
-                                implicitSize: 22
+                                implicitSize: root.iconSize
 
                                 source: {
                                     const file = rowItem.modelData;

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -258,6 +258,7 @@ StyledRect {
         id: detailsComp
         FileDetailsView {
             model: mainModel
+            zoomSize: root.zoomSize
             activeTab: root.activeTab
             paneIndex: 0
             onOpenItem: item => root.handleOpen(item, 0)
@@ -280,6 +281,7 @@ StyledRect {
         id: compactComp
         FileCompactView {
             model: mainModel
+            zoomSize: root.zoomSize
             activeTab: root.activeTab
             paneIndex: 0
             onOpenItem: item => root.handleOpen(item, 0)
@@ -326,6 +328,7 @@ StyledRect {
         id: splitDetailsComp
         FileDetailsView {
             model: splitModel
+            zoomSize: root.zoomSize
             activeTab: root.activeTab
             paneIndex: 1
             onOpenItem: item => root.handleOpen(item, 1)
@@ -348,6 +351,7 @@ StyledRect {
         id: splitCompactComp
         FileCompactView {
             model: splitModel
+            zoomSize: root.zoomSize
             activeTab: root.activeTab
             paneIndex: 1
             onOpenItem: item => root.handleOpen(item, 1)


### PR DESCRIPTION
## Problem

The zoom slider and `Ctrl+Scroll` change the zoom level from every view, but only `FileGridView` reads it. In the details and compact views the handle moves and the value updates, yet nothing on screen changes.

The `Ctrl+Scroll` handlers in `FileDetailsView.qml` and `FileCompactView.qml` already write to `window.zoomLevel`, so the control was wired up on the input side only.

## Change

Both views now derive their metrics from `zoomSize`, and `SplitViewContainer` passes it to all four view instances.

| | Details | Compact |
|---|---|---|
| icon | `22 * zoom / 80`, clamped to 16–64 | `20 * zoom / 80`, clamped to 16–64 |
| row / cell height | `max(36, icon + 14)` | `icon + 18` |
| cell width | — | `max(220, 200 + icon)` |

At the default zoom level of 80 these evaluate to exactly the constants they replace — 22 and 36 for details, 20 and 38 for compact — so the views are pixel-identical unless the zoom is actually used.

The clamp is deliberately tighter than the grid view's 48–180. A 180 px icon in a list row is not useful, and at the 64 px upper bound a details row is already 78 px tall. The row height also never drops below the original 36 px so the text does not get cramped at the low end.
