### PR TITLE
fix: shrink grid cell padding at small icon sizes

### DIFF
--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -12,6 +12,14 @@ Item {
     required property var activeTab
     property int paneIndex: 0
     property real zoomSize: 80
+    readonly property int labelLines: zoomSize < 64 ? 2 : (zoomSize < 80 ? 3 : 4)
+    readonly property int labelHeight: Math.ceil(labelMetrics.height) * labelLines
+
+    FontMetrics {
+        id: labelMetrics
+        font: Tokens.font.body.small
+    }
+
     property int currentIndex: view.currentIndex
     readonly property var currentItem: {
         if (view.currentIndex >= 0 && root.model && view.currentIndex < root.model.count) {
@@ -123,7 +131,7 @@ Item {
 
         // Exact uniform cell dimensions
         cellWidth: Math.max(144, root.zoomSize + 48)
-        cellHeight: root.zoomSize + 84
+        cellHeight: 16 + root.zoomSize + root.labelHeight
 
         clip: true
         focus: true
@@ -573,7 +581,7 @@ Item {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignTop
                     elide: Text.ElideMiddle
-                    maximumLineCount: 4
+                    maximumLineCount: root.labelLines
                     wrapMode: Text.WrapAnywhere
                 }
             }


### PR DESCRIPTION
## Problem

Grid cell height was `zoomSize + 84`, and the 84 breaks down as:

```
 8 px   top margin
 zoom   icon
 4 px   gap
68 px   label — maximumLineCount: 4
 4 px   bottom margin
```

The label area is sized for four lines whatever the icon size is, because the font does not scale with the zoom. At the smallest zoom that puts a 48 px icon above 68 px of label space, most of it empty, and the cell reads as mostly padding.

## Change

Compute the cell height from the icon size and the label line count, and step the line count down for smaller icons:

| zoom | label lines |
|---|---|
| `< 64` | 2 |
| `< 80` | 3 |
| `>= 80` | 4 |

`maximumLineCount` follows the same value, so the text box and the reserved space stay in agreement.

Line height comes from `FontMetrics` on the label font rather than a constant, so the arithmetic stays correct if the font configuration changes.

At the default zoom of 80 the result is four lines and the previous height, so the default layout is unchanged. The trade-off is that long names elide earlier at small icon sizes, which is the intent — small icons are for scanning a dense grid, not for reading full names.
