### PR TITLE
fix: break long names at word boundaries before splitting them

### DIFF
--- a/qml/components/dialogs/OperationsModal.qml
+++ b/qml/components/dialogs/OperationsModal.qml
@@ -261,7 +261,7 @@ Item {
                                         text: completedItem.modelData.message || ""
                                         color: Colours.palette.m3onSurface
                                         font: Tokens.font.body.small
-                                        wrapMode: Text.WrapAnywhere
+                                        wrapMode: Text.Wrap
                                     }
 
                                     StyledText {

--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -297,7 +297,7 @@ Item {
                     verticalAlignment: Text.AlignTop
                     elide: Text.ElideMiddle
                     maximumLineCount: 4
-                    wrapMode: Text.WrapAnywhere
+                    wrapMode: Text.Wrap
                 }
             }
         }

--- a/qml/components/panels/PreviewPanel.qml
+++ b/qml/components/panels/PreviewPanel.qml
@@ -130,7 +130,7 @@ StyledRect {
                     text: meta.name.length > 0 ? meta.name : qsTr("No Selection")
                     color: Colours.palette.m3onSurface
                     font: Tokens.font.title.small
-                    wrapMode: Text.WrapAnywhere
+                    wrapMode: Text.Wrap
                 }
 
                 StyledText {
@@ -190,7 +190,7 @@ StyledRect {
                         text: modelData.value ? String(modelData.value) : ""
                         color: Colours.palette.m3onSurface
                         font: Tokens.font.body.small
-                        wrapMode: Text.WrapAnywhere
+                        wrapMode: Text.Wrap
                     }
                 }
             }

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -574,7 +574,7 @@ Item {
                     verticalAlignment: Text.AlignTop
                     elide: Text.ElideMiddle
                     maximumLineCount: 4
-                    wrapMode: Text.WrapAnywhere
+                    wrapMode: Text.Wrap
                 }
             }
         }


### PR DESCRIPTION
## Problem

Five labels use `Text.WrapAnywhere`, which breaks at whatever character happens to reach the edge and ignores separators that are right there:

```
caelestia-backu     midnight-shell-g     Fedora-Hyprlan
p                   it                   d
```

The same mode is applied to operation messages in `OperationsModal`, where breaking prose mid-word is harder to read than breaking file names.

## Change

Switch all five to `Text.Wrap`, which prefers word boundaries and only breaks inside a word when a single run is too wide to fit on its own line:

- `FileGridView` — grid cell label
- `FolderContents` — grid cell label in the file dialog
- `PreviewPanel` — file name and metadata values
- `OperationsModal` — operation message

Names now break as `caelestia-` / `backup` and `midnight-shell-` / `git`.

Names separated only by periods, such as `.claude.json.backup`, still break mid-word. That is correct per the Unicode line breaking rules: a hyphen is a break opportunity, a period between letters is not. Changing that would need custom hyphenation logic and is out of scope here.
