### PR TITLE
feat: reveal Delete Permanently in the context menu while Shift is held

### DIFF
--- a/qml/components/menus/ContextMenu.qml
+++ b/qml/components/menus/ContextMenu.qml
@@ -15,6 +15,7 @@ MouseArea {
     property real submenuY: 0
     property var sharingServices: []
     property var customActions: []
+    property bool shiftHeld: false
 
     readonly property bool isTrash: currentDir.indexOf("Trash") !== -1 || currentDir.indexOf("trash:") !== -1 || (targetItem && targetItem.isTrashItem)
     readonly property bool isArchive: targetItem && (
@@ -28,6 +29,7 @@ MouseArea {
     onExpandedChanged: {
         submenuOpen = false;
         if (expanded) {
+            shiftHeld = AppController.shiftPressed();
             sharingServices = AppIntegration.getAvailableSharingServices();
             let selPaths = targetItem ? [targetItem.path] : [];
             let isDir = targetItem ? targetItem.isDir : true;
@@ -142,7 +144,11 @@ MouseArea {
                         list.push({ text: qsTr("Create Symlink"), icon: "link", action: "symlink" });
                         list.push({ text: qsTr("Rename"), icon: "drive_file_rename_outline", action: "rename" });
                         list.push({ text: qsTr("Duplicate"), icon: "control_point_duplicate", action: "duplicate" });
-                        list.push({ text: qsTr("Move to Trash"), icon: "delete", action: "trash" });
+                        if (root.shiftHeld) {
+                            list.push({ text: qsTr("Delete Permanently"), icon: "delete_forever", action: "delete" });
+                        } else {
+                            list.push({ text: qsTr("Move to Trash"), icon: "delete", action: "trash" });
+                        }
                         list.push({ text: qsTr("Properties"), icon: "info", action: "properties" });
 
                         return list;

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -1,4 +1,6 @@
 #include "appcontroller.hpp"
+
+#include <QGuiApplication>
 #include "iconprovider.hpp"
 #include <QSettings>
 #include <iostream>
@@ -58,6 +60,10 @@ void AppController::setDirectoryOnly(bool dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
     }
+}
+
+bool AppController::shiftPressed() {
+    return QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier);
 }
 
 void AppController::setShowHidden(bool show) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -53,6 +53,7 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    Q_INVOKABLE static bool shiftPressed();
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }


### PR DESCRIPTION
## Problem

Outside the trash, permanent deletion is only reachable through `Shift+Delete`. The context menu offers **Move to Trash** and nothing else, so the feature is undiscoverable for anyone who does not already know the shortcut. **Delete Permanently** exists in the menu only for items already in the trash.

## Change

While Shift is held as the menu opens, **Move to Trash** is replaced by **Delete Permanently**, using the same `delete_forever` icon and error colour the trash menu already uses for that action. This matches Thunar and Dolphin.

The action reuses the existing `"delete"` case, so it goes through the same code path as the trash menu entry and the keyboard shortcut.

## Implementation notes

The context menu signals stay unchanged. Extending `itemContextMenu(item, x, y)` with a modifier argument would have touched around twenty call sites across three views and six forwarding pairs in `SplitViewContainer`, which is a lot of churn for one menu entry.

Instead the menu asks for the real keyboard state on open via `QGuiApplication::queryKeyboardModifiers()`. That reports the physical state rather than the modifiers of the last delivered event, which matters here because the usual gesture is to press Shift *before* right-clicking, so no key event arrives while the menu is open.

The entry is therefore decided when the menu opens and does not swap live afterwards. Live swapping would require the menu to take keyboard focus, which it currently never does, and that seemed the riskier trade.
