### PR TITLE
fix: show progress while a directory loads and ignore stale activations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ qt_add_qml_module(prism_app
         qml/components/views/FileCompactView.qml
         qml/components/views/SplitViewContainer.qml
         qml/components/views/EmptyStateView.qml
+        qml/components/views/LoadingOverlay.qml
         qml/components/menus/ContextMenu.qml
         qml/components/menus/TabContextMenu.qml
         qml/components/menus/PlaceContextMenu.qml

--- a/qml/components/views/LoadingOverlay.qml
+++ b/qml/components/views/LoadingOverlay.qml
@@ -1,0 +1,60 @@
+import QtQuick
+import "../"
+import prism
+
+Item {
+    id: root
+
+    property bool active: false
+    property bool shown: false
+
+    anchors.fill: parent
+    z: 30
+    visible: opacity > 0.01
+    opacity: shown ? 1 : 0
+
+    Behavior on opacity {
+        Anim {
+            type: Anim.FastEffects
+        }
+    }
+
+    onActiveChanged: {
+        if (active) {
+            delay.restart();
+        } else {
+            delay.stop();
+            root.shown = false;
+        }
+    }
+
+    Timer {
+        id: delay
+        interval: 250
+        onTriggered: root.shown = root.active
+    }
+
+    StyledRect {
+        anchors.centerIn: parent
+        implicitWidth: 64
+        implicitHeight: 64
+        radius: Tokens.rounding.full
+        color: Colours.tPalette.m3surfaceContainerHigh
+
+        MaterialIcon {
+            id: spinner
+            anchors.centerIn: parent
+            text: "progress_activity"
+            color: Colours.palette.m3primary
+            fontStyle: Tokens.font.icon.large
+
+            RotationAnimator on rotation {
+                running: root.shown
+                from: 0
+                to: 360
+                duration: 1000
+                loops: Animation.Infinite
+            }
+        }
+    }
+}

--- a/qml/components/views/LoadingOverlay.qml
+++ b/qml/components/views/LoadingOverlay.qml
@@ -10,7 +10,7 @@ Item {
 
     anchors.fill: parent
     z: 30
-    visible: opacity > 0.01
+    visible: active || opacity > 0.01
     opacity: shown ? 1 : 0
 
     Behavior on opacity {
@@ -32,6 +32,14 @@ Item {
         id: delay
         interval: 250
         onTriggered: root.shown = root.active
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        enabled: root.active
+        acceptedButtons: Qt.AllButtons
+        cursorShape: root.shown ? Qt.BusyCursor : Qt.ArrowCursor
+        onWheel: wheel => wheel.accepted = true
     }
 
     StyledRect {

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -100,8 +100,12 @@ StyledRect {
             }
 
             // Nexus-Style Empty State
+            LoadingOverlay {
+                active: mainModel.isLoading
+            }
+
             EmptyStateView {
-                visible: mainModel.count === 0
+                visible: mainModel.count === 0 && !mainModel.isLoading
                 path: root.activeTab ? root.activeTab.currentPath : ""
                 isSearching: mainModel.isSearching
                 searchQuery: (root.isSplit && root.activePane === 1) ? "" : root.searchQuery
@@ -213,8 +217,12 @@ StyledRect {
             }
 
             // Secondary Empty State
+            LoadingOverlay {
+                active: splitModel.isLoading
+            }
+
             EmptyStateView {
-                visible: splitModel.count === 0
+                visible: splitModel.count === 0 && !splitModel.isLoading
                 path: (root.activeTab && root.activeTab.splitPath) ? root.activeTab.splitPath : ""
                 isSearching: splitModel.isSearching
                 searchQuery: (root.isSplit && root.activePane === 1) ? root.searchQuery : ""
@@ -369,6 +377,7 @@ StyledRect {
     function handleOpen(item, pane) {
         if (root.activeTab) root.activeTab.activePane = pane;
         if (!item) return;
+        if ((pane === 1 ? splitModel : mainModel).isLoading) return;
         if (item.isDir) {
             if (pane === 1) {
                 root.activeTab.splitPath = item.path;

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -300,6 +300,9 @@ static FileSystemEntry* createEntryFromRawData(const RawEntryData& d, QObject* p
 }
 
 void FileSystemModel::scanDirectory(bool isPathReset) {
+    const auto generationToken = m_scanGeneration;
+    const quint64 generation = generationToken->fetch_add(1, std::memory_order_relaxed) + 1;
+
     if (!m_watcher.directories().isEmpty())
         m_watcher.removePaths(m_watcher.directories());
 
@@ -326,7 +329,7 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
         emit isLoadingChanged();
     }
 
-    (void)QtConcurrent::run([this, scanPath, isPathReset]() {
+    (void)QtConcurrent::run([this, scanPath, isPathReset, generationToken, generation]() {
         QDir dir(scanPath);
         QFileInfoList list = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
         QMimeDatabase mimeDb;
@@ -334,11 +337,13 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
         QList<RawEntryData> rawData;
         rawData.reserve(list.size());
         for (const auto& fi : list) {
+            if (generationToken->load(std::memory_order_relaxed) != generation)
+                return;
             rawData.append(createRawDataFromInfo(fi, mimeDb));
         }
 
-        QMetaObject::invokeMethod(this, [this, rawData, scanPath, isPathReset]() {
-            if (m_path != scanPath)
+        QMetaObject::invokeMethod(this, [this, rawData, isPathReset, generationToken, generation]() {
+            if (generationToken->load(std::memory_order_relaxed) != generation)
                 return;
 
             if (m_isLoading) {

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -304,6 +304,11 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
         m_watcher.removePaths(m_watcher.directories());
 
     if (m_path.isEmpty() || !QDir(m_path).exists()) {
+        if (m_isLoading) {
+            m_isLoading = false;
+            emit isLoadingChanged();
+        }
+
         beginResetModel();
         qDeleteAll(m_rawEntries);
         m_rawEntries.clear();
@@ -315,6 +320,11 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
 
     m_watcher.addPath(m_path);
     QString scanPath = m_path;
+
+    if (isPathReset && !m_isLoading) {
+        m_isLoading = true;
+        emit isLoadingChanged();
+    }
 
     (void)QtConcurrent::run([this, scanPath, isPathReset]() {
         QDir dir(scanPath);
@@ -330,6 +340,11 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
         QMetaObject::invokeMethod(this, [this, rawData, scanPath, isPathReset]() {
             if (m_path != scanPath)
                 return;
+
+            if (m_isLoading) {
+                m_isLoading = false;
+                emit isLoadingChanged();
+            }
 
             if (isPathReset || m_rawEntries.isEmpty()) {
                 beginResetModel();

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -4,8 +4,10 @@
 #include <QDateTime>
 #include <QFileSystemWatcher>
 #include <QList>
+#include <QSharedPointer>
 #include <QString>
 #include <QStringList>
+#include <atomic>
 #include <qqmlintegration.h>
 
 namespace prism::models {
@@ -235,6 +237,7 @@ private:
     QString m_searchQuery;
     bool m_isSearching = false;
     bool m_isLoading = false;
+    QSharedPointer<std::atomic<quint64>> m_scanGeneration = QSharedPointer<std::atomic<quint64>>::create(0);
     bool m_isPathReset = false;
     QStringList m_nameFilters;
     bool m_showHidden = false;

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -135,6 +135,7 @@ class FileSystemModel : public QAbstractListModel {
     Q_PROPERTY(QString filterText READ filterText WRITE setFilterText NOTIFY filterTextChanged)
     Q_PROPERTY(QString searchQuery READ searchQuery WRITE setSearchQuery NOTIFY searchQueryChanged)
     Q_PROPERTY(bool isSearching READ isSearching NOTIFY isSearchingChanged)
+    Q_PROPERTY(bool isLoading READ isLoading NOTIFY isLoadingChanged)
     Q_PROPERTY(QStringList nameFilters READ nameFilters WRITE setNameFilters NOTIFY nameFiltersChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
@@ -185,6 +186,7 @@ public:
     QString searchQuery() const { return m_searchQuery; }
     void setSearchQuery(const QString& query);
     bool isSearching() const { return m_isSearching; }
+    bool isLoading() const { return m_isLoading; }
 
     QStringList nameFilters() const { return m_nameFilters; }
     void setNameFilters(const QStringList& filters);
@@ -212,6 +214,7 @@ signals:
     void filterTextChanged();
     void searchQueryChanged();
     void isSearchingChanged();
+    void isLoadingChanged();
     void nameFiltersChanged();
     void showHiddenChanged();
     void showDirsFirstChanged();
@@ -231,6 +234,7 @@ private:
     QString m_filterText;
     QString m_searchQuery;
     bool m_isSearching = false;
+    bool m_isLoading = false;
     bool m_isPathReset = false;
     QStringList m_nameFilters;
     bool m_showHidden = false;


### PR DESCRIPTION
## Problem

Reported by @Evertiro.

`scanDirectory` enumerates on a worker thread and only calls `beginResetModel` once the whole listing is ready. Until then the view keeps showing the previous directory, with no indication that anything is happening.

On a large directory that reads as a click that did not register. If you double click again, the second activation is applied after the new listing has appeared, so it opens whichever file now happens to sit under the cursor.

## Change

**`isLoading` on the model.** Set when a path change starts a scan, cleared when that scan delivers. Deliberately not set for the granular updates the file watcher triggers, otherwise the indicator would blink on every change inside the current directory.

**A spinner after a short delay.** `LoadingOverlay` fades in 250 ms after loading starts, so ordinary directories never show it.

**Pointer input blocked for the duration of the load.** The overlay takes the events itself and becomes transparent again the moment loading ends.

**Scans abandoned when the path changes.** A scan carries a generation token and stops at the next entry once a newer scan has been started.

The empty state is also suppressed during a load, so navigating out of an empty directory no longer flashes "This folder is empty" over the spinner.

## On blocking input

The first version guarded `handleOpen` instead, on the reasoning that a single check cannot strand a pane the way a stuck overlay could. @Evertiro pointed out the hole: `handleOpen` is the activation path, and right click never goes through it, so the context menu still opened on a listing that was about to be replaced.

Guarding each entry point separately means every future one has to remember to do the same, so the overlay now blocks instead. It blocks from the moment the model reports loading rather than from the moment the spinner appears, so a fast load has no window where a click still lands. The wheel is included, since scrolling a listing that is about to be replaced under a spinner looked broken. The cursor turns busy once the spinner is actually on screen.

That leaves the original concern, and the answer is that `isLoading` has no path to being stuck true. Every scan either delivers and clears it, or is superseded by one that will; a path that does not exist clears it directly.

## On abandoning scans

Only the delivery used to be discarded, via `m_path != scanPath`, which is reached after the entire listing has already been built. A large directory therefore kept a pool thread busy well after the user had moved on, delaying the scan they were actually waiting for. That is what made navigating away from a slow directory feel worse than staying in it.

The generation token is held by shared pointer and captured by value, so the worker never dereferences the model to decide whether to keep going. Closing a tab mid-scan would otherwise read a member of a destroyed object, which is a pre-existing hazard the old `m_path` check had as well.

The delivery check now tests the generation rather than the path, which is strictly stronger: navigating away and back again starts a new scan, and the abandoned one should not deliver into it.

## Notes

The 250 ms delay is the one tunable number. Shorter makes ordinary directories flicker, longer leaves mid-sized directories without feedback.

Verified against a directory of 20000 files: the spinner appears, left click, double click, right click and the wheel do nothing while it is up, navigating away releases the pane immediately, and ordinary directories show no indicator at all.
