### PR TITLE
feat: add thumbnail rules

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -303,6 +303,116 @@ MouseArea {
                                 }
                             }
 
+                            StyledRect {
+                                Layout.fillWidth: true
+                                implicitHeight: 56
+                                radius: Tokens.rounding.large
+                                color: thumbHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Tokens.padding.medium
+                                    anchors.rightMargin: Tokens.padding.medium
+                                    spacing: Tokens.spacing.medium
+
+                                    MaterialIcon {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        text: AppController.thumbnailsEnabled ? "image" : "hide_image"
+                                        color: AppController.thumbnailsEnabled ? Colours.palette.m3primary : Colours.palette.m3outline
+                                        fontStyle: Tokens.font.icon.medium
+                                    }
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        Layout.alignment: Qt.AlignVCenter
+                                        spacing: 2
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Show Thumbnails")
+                                            color: Colours.palette.m3onSurface
+                                            font: Tokens.font.body.small
+                                            elide: Text.ElideRight
+                                        }
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Preview images and videos instead of generic icons")
+                                            color: Colours.palette.m3onSurfaceVariant
+                                            font: Tokens.font.label.small
+                                            elide: Text.ElideRight
+                                        }
+                                    }
+
+                                    StyledCheckBox {
+                                        Layout.alignment: Qt.AlignVCenter
+                                        checked: AppController.thumbnailsEnabled
+                                        onToggled: val => AppController.thumbnailsEnabled = val
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: thumbHover
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: AppController.thumbnailsEnabled = !AppController.thumbnailsEnabled
+                                }
+                            }
+
+                            StyledText {
+                                text: qsTr("Thumbnail Size Limit")
+                                color: Colours.palette.m3primary
+                                font: Tokens.font.label.large
+                                opacity: AppController.thumbnailsEnabled ? 1 : 0.4
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Tokens.spacing.small
+                                enabled: AppController.thumbnailsEnabled
+                                opacity: enabled ? 1 : 0.4
+
+                                Repeater {
+                                    model: [
+                                        { mb: 10, label: qsTr("10 MB") },
+                                        { mb: 100, label: qsTr("100 MB") },
+                                        { mb: 1024, label: qsTr("1 GB") },
+                                        { mb: 0, label: qsTr("No limit") }
+                                    ]
+
+                                    StyledRect {
+                                        id: limitCard
+                                        required property int index
+                                        required property var modelData
+
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.thumbnailMaxMb === limitCard.modelData.mb
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (limitHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        StyledText {
+                                            anchors.centerIn: parent
+                                            text: limitCard.modelData.label
+                                            color: limitCard.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                            font: Tokens.font.body.small
+                                            elide: Text.ElideRight
+                                        }
+
+                                        MouseArea {
+                                            id: limitHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.thumbnailMaxMb = limitCard.modelData.mb
+                                        }
+                                    }
+                                }
+                            }
+
                             // Single-click toggle card
                             StyledRect {
                                 Layout.fillWidth: true

--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -232,7 +232,7 @@ Item {
                         source: {
                             const file = delegateContainer.modelData;
                             if (!file) return "";
-                            if (file.isImage || file.isVideo) {
+                            if (file.hasThumbnail) {
                                 let t = file.lastModified ? file.lastModified.getTime() : file.size;
                                 return "image://thumb/" + file.path + "?t=" + t;
                             } else {

--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -493,7 +493,7 @@ Item {
                             source: {
                                 const file = compDelegate.modelData;
                                 if (!file) return "";
-                                if (file.isImage || file.isVideo) {
+                                if (file.hasThumbnail) {
                                     let t = file.lastModified ? file.lastModified.getTime() : file.size;
                                     return "image://thumb/" + file.path + "?t=" + t;
                                 } else {

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -701,7 +701,7 @@ Item {
                                 source: {
                                     const file = rowItem.modelData;
                                     if (!file) return "";
-                                    if (file.isImage || file.isVideo) {
+                                    if (file.hasThumbnail) {
                                         let t = file.lastModified ? file.lastModified.getTime() : file.size;
                                         return "image://thumb/" + file.path + "?t=" + t;
                                     } else {

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -509,7 +509,7 @@ Item {
                         source: {
                             const file = delegateContainer.modelData;
                             if (!file) return "";
-                            if (file.isImage || file.isVideo) {
+                            if (file.hasThumbnail) {
                                 let t = file.lastModified ? file.lastModified.getTime() : file.size;
                                 return "image://thumb/" + file.path + "?t=" + t;
                             } else {

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -39,6 +39,18 @@ StyledRect {
     }
     readonly property var activeModel: (isSplit && activePane === 1) ? splitModel : mainModel
 
+    Connections {
+        target: AppController
+        function onThumbnailsEnabledChanged() {
+            if (mainModel) mainModel.refresh();
+            if (splitModel) splitModel.refresh();
+        }
+        function onThumbnailMaxMbChanged() {
+            if (mainModel) mainModel.refresh();
+            if (splitModel) splitModel.refresh();
+        }
+    }
+
     signal itemContextMenu(var item, real mouseX, real mouseY)
     signal blankContextMenu(real mouseX, real mouseY)
     signal filesDropped(var sources, string destDir, real mouseX, real mouseY)

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -1,4 +1,5 @@
 #include "appcontroller.hpp"
+#include "fileutils.hpp"
 #include "iconprovider.hpp"
 #include <QSettings>
 #include <iostream>
@@ -18,6 +19,10 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+    m_thumbnailsEnabled = settings.value("preferences/thumbnailsEnabled", true).toBool();
+    m_thumbnailMaxMb = settings.value("preferences/thumbnailMaxMb", 0).toInt();
+    FileUtils::setThumbnailsEnabled(m_thumbnailsEnabled);
+    FileUtils::setThumbnailMaxBytes(static_cast<qint64>(m_thumbnailMaxMb) * 1024 * 1024);
 }
 
 AppController* AppController::instance() {
@@ -57,6 +62,26 @@ void AppController::setDirectoryOnly(bool dirOnly) {
     if (m_directoryOnly != dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
+    }
+}
+
+void AppController::setThumbnailsEnabled(bool enabled) {
+    if (m_thumbnailsEnabled != enabled) {
+        m_thumbnailsEnabled = enabled;
+        FileUtils::setThumbnailsEnabled(enabled);
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/thumbnailsEnabled", enabled);
+        emit thumbnailsEnabledChanged();
+    }
+}
+
+void AppController::setThumbnailMaxMb(int mb) {
+    if (m_thumbnailMaxMb != mb) {
+        m_thumbnailMaxMb = mb;
+        FileUtils::setThumbnailMaxBytes(static_cast<qint64>(mb) * 1024 * 1024);
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/thumbnailMaxMb", mb);
+        emit thumbnailMaxMbChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -19,6 +19,8 @@ class AppController : public QObject {
     Q_PROPERTY(QStringList filters READ filters WRITE setFilters NOTIFY filtersChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+    Q_PROPERTY(bool thumbnailsEnabled READ thumbnailsEnabled WRITE setThumbnailsEnabled NOTIFY thumbnailsEnabledChanged)
+    Q_PROPERTY(int thumbnailMaxMb READ thumbnailMaxMb WRITE setThumbnailMaxMb NOTIFY thumbnailMaxMbChanged)
     Q_PROPERTY(bool singleClick READ singleClick WRITE setSingleClick NOTIFY singleClickChanged)
     Q_PROPERTY(QString defaultStartupDirectory READ defaultStartupDirectory WRITE setDefaultStartupDirectory NOTIFY defaultStartupDirectoryChanged)
     Q_PROPERTY(int defaultViewMode READ defaultViewMode WRITE setDefaultViewMode NOTIFY defaultViewModeChanged)
@@ -53,6 +55,10 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    [[nodiscard]] bool thumbnailsEnabled() const { return m_thumbnailsEnabled; }
+    void setThumbnailsEnabled(bool enabled);
+    [[nodiscard]] int thumbnailMaxMb() const { return m_thumbnailMaxMb; }
+    void setThumbnailMaxMb(int mb);
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }
@@ -88,6 +94,8 @@ signals:
     void filtersChanged();
     void directoryOnlyChanged();
     void showHiddenChanged();
+    void thumbnailsEnabledChanged();
+    void thumbnailMaxMbChanged();
     void singleClickChanged();
     void defaultStartupDirectoryChanged();
     void defaultViewModeChanged();
@@ -107,6 +115,8 @@ private:
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
     bool m_showHidden = false;
+    bool m_thumbnailsEnabled = true;
+    int m_thumbnailMaxMb = 0;
     bool m_singleClick = false;
     QString m_defaultStartupDirectory = "home";
     int m_defaultViewMode = 0; // Grid, Details, Compact

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -1,4 +1,6 @@
 #include "fileutils.hpp"
+
+#include <atomic>
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeDatabase>
@@ -36,6 +38,29 @@ QString FileUtils::music() const {
 
 QString FileUtils::desktop() const {
     return QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+}
+
+namespace {
+std::atomic<bool> g_thumbsEnabled{true};
+std::atomic<qint64> g_thumbMaxBytes{0};
+}
+
+void FileUtils::setThumbnailsEnabled(bool enabled) {
+    g_thumbsEnabled.store(enabled, std::memory_order_relaxed);
+}
+
+void FileUtils::setThumbnailMaxBytes(qint64 bytes) {
+    g_thumbMaxBytes.store(bytes, std::memory_order_relaxed);
+}
+
+bool FileUtils::shouldThumbnail(bool isImage, bool isVideo, qint64 size) {
+    if (!isImage && !isVideo)
+        return false;
+    if (!g_thumbsEnabled.load(std::memory_order_relaxed))
+        return false;
+
+    const qint64 limit = g_thumbMaxBytes.load(std::memory_order_relaxed);
+    return limit <= 0 || size <= limit;
 }
 
 QString FileUtils::formatSize(qint64 bytes) {

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -32,6 +32,9 @@ public:
     [[nodiscard]] QString desktop() const;
 
     Q_INVOKABLE static QString formatSize(qint64 bytes);
+    Q_INVOKABLE static bool shouldThumbnail(bool isImage, bool isVideo, qint64 size);
+    static void setThumbnailsEnabled(bool enabled);
+    static void setThumbnailMaxBytes(qint64 bytes);
     Q_INVOKABLE static QString shortenHome(const QString& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
     Q_INVOKABLE static QString baseName(const QString& path);

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -214,6 +214,8 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
         d.isText = true;
     }
 
+    d.hasThumbnail = prism::core::FileUtils::shouldThumbnail(d.isImage, d.isVideo, d.size);
+
     if (fi.absolutePath().contains("/.local/share/Trash/files") || fi.absolutePath().contains("/Trash/files")) {
         d.isTrashItem = true;
         QString infoPath = QDir::homePath() + "/.local/share/Trash/info/" + fi.fileName() + ".trashinfo";
@@ -262,6 +264,7 @@ bool FileSystemEntry::updateFromRaw(const RawEntryData& d) {
     if (m_isImage != d.isImage) { m_isImage = d.isImage; changed = true; }
     if (m_isAudio != d.isAudio) { m_isAudio = d.isAudio; changed = true; }
     if (m_isVideo != d.isVideo) { m_isVideo = d.isVideo; changed = true; }
+    if (m_hasThumbnail != d.hasThumbnail) { m_hasThumbnail = d.hasThumbnail; changed = true; }
     if (m_isText != d.isText) { m_isText = d.isText; changed = true; }
     if (m_originalPath != d.originalPath) { m_originalPath = d.originalPath; changed = true; }
     if (m_deletionTime != d.deletionTime) { m_deletionTime = d.deletionTime; changed = true; }
@@ -292,6 +295,7 @@ static FileSystemEntry* createEntryFromRawData(const RawEntryData& d, QObject* p
     entry->m_isImage = d.isImage;
     entry->m_isAudio = d.isAudio;
     entry->m_isVideo = d.isVideo;
+    entry->m_hasThumbnail = d.hasThumbnail;
     entry->m_isText = d.isText;
     entry->m_originalPath = d.originalPath;
     entry->m_deletionTime = d.deletionTime;

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -32,6 +32,7 @@ struct RawEntryData {
     bool isImage = false;
     bool isAudio = false;
     bool isVideo = false;
+    bool hasThumbnail = false;
     bool isText = false;
     QString originalPath;
     QString deletionTime;
@@ -64,6 +65,7 @@ class FileSystemEntry : public QObject {
     Q_PROPERTY(bool isImage READ isImage CONSTANT)
     Q_PROPERTY(bool isAudio READ isAudio CONSTANT)
     Q_PROPERTY(bool isVideo READ isVideo CONSTANT)
+    Q_PROPERTY(bool hasThumbnail READ hasThumbnail CONSTANT)
     Q_PROPERTY(bool isText READ isText CONSTANT)
     Q_PROPERTY(QString originalPath READ originalPath CONSTANT)
     Q_PROPERTY(QString deletionTime READ deletionTime CONSTANT)
@@ -93,6 +95,7 @@ public:
     bool isImage() const { return m_isImage; }
     bool isAudio() const { return m_isAudio; }
     bool isVideo() const { return m_isVideo; }
+    bool hasThumbnail() const { return m_hasThumbnail; }
     bool isText() const { return m_isText; }
     QString originalPath() const { return m_originalPath; }
     QString deletionTime() const { return m_deletionTime; }
@@ -124,6 +127,7 @@ public:
     bool m_isImage = false;
     bool m_isAudio = false;
     bool m_isVideo = false;
+    bool m_hasThumbnail = false;
     bool m_isText = false;
 };
 


### PR DESCRIPTION
## Problem

Thumbnails are generated for every image and video, whatever its size, and there is no way to switch them off. A directory of 4K videos or camera raws keeps the thumbnailer busy producing previews the user may not want, and on slow storage that is felt.

## Change

Two preferences under File Display & Navigation:

- **Show Thumbnails** — on by default
- **Thumbnail Size Limit** — 10 MB, 100 MB, 1 GB or no limit, defaulting to no limit

Both defaults reproduce the current behaviour exactly, so nothing changes unless configured.

## Implementation notes

The rule lives in `FileUtils::shouldThumbnail(isImage, isVideo, size)` and is evaluated once per entry while the directory is read, exposed to QML as a `hasThumbnail` property on the model. The four views that were each testing `file.isImage || file.isVideo` now ask for `file.hasThumbnail` instead.

Deciding in the model rather than in the delegates keeps the logic in one place and off the render path, and the check already has the file size at hand from the same `QFileInfo`.

Settings are cached in atomics because directory reads happen on worker threads, and both panes refresh through a `Connections` block when either preference changes.

## Not included

Thunar's third state, thumbnails for local files only, is left out. Prism has no network or remote mounts yet, so the option would behave identically to "always" and only add a control that does nothing. It slots in naturally once remote locations exist.
