### PR TITLE
feat: let the details view columns be turned off

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -531,6 +531,171 @@ MouseArea {
                             Item { implicitHeight: 4 }
 
                             StyledText {
+                                text: qsTr("Details View Columns")
+                                color: Colours.palette.m3primary
+                                font: Tokens.font.label.large
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: Tokens.spacing.small
+
+                                    StyledRect {
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.showSizeColumn
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (colSizeHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        RowLayout {
+                                            anchors.centerIn: parent
+                                            spacing: 6
+
+                                            MaterialIcon {
+                                                text: "straighten"
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                                                fontStyle: Tokens.font.icon.small
+                                            }
+
+                                            StyledText {
+                                                text: qsTr("Size")
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            id: colSizeHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.showSizeColumn = !AppController.showSizeColumn
+                                        }
+                                    }
+
+                                    StyledRect {
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.showTypeColumn
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (colTypeHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        RowLayout {
+                                            anchors.centerIn: parent
+                                            spacing: 6
+
+                                            MaterialIcon {
+                                                text: "category"
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                                                fontStyle: Tokens.font.icon.small
+                                            }
+
+                                            StyledText {
+                                                text: qsTr("Type")
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            id: colTypeHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.showTypeColumn = !AppController.showTypeColumn
+                                        }
+                                    }
+
+                                    StyledRect {
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.showDateColumn
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (colDateHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        RowLayout {
+                                            anchors.centerIn: parent
+                                            spacing: 6
+
+                                            MaterialIcon {
+                                                text: "schedule"
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                                                fontStyle: Tokens.font.icon.small
+                                            }
+
+                                            StyledText {
+                                                text: qsTr("Date Modified")
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            id: colDateHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.showDateColumn = !AppController.showDateColumn
+                                        }
+                                    }
+
+                                    StyledRect {
+                                        Layout.fillWidth: true
+                                        implicitHeight: 44
+                                        radius: Tokens.rounding.medium
+                                        readonly property bool isSelected: AppController.showPermissionsColumn
+                                        color: isSelected
+                                            ? Colours.palette.m3primaryContainer
+                                            : (colPermissionsHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                                        RowLayout {
+                                            anchors.centerIn: parent
+                                            spacing: 6
+
+                                            MaterialIcon {
+                                                text: "lock"
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurfaceVariant
+                                                fontStyle: Tokens.font.icon.small
+                                            }
+
+                                            StyledText {
+                                                text: qsTr("Permissions")
+                                                color: parent.parent.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            id: colPermissionsHover
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: AppController.showPermissionsColumn = !AppController.showPermissionsColumn
+                                        }
+                                    }
+                            }
+
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: qsTr("The name column is always shown")
+                                color: Colours.palette.m3onSurfaceVariant
+                                font: Tokens.font.label.small
+                                elide: Text.ElideRight
+                            }
+
+                            Item { implicitHeight: 4 }
+
+                            StyledText {
                                 text: qsTr("Places Sidebar Icon Size")
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -176,7 +176,7 @@ Item {
 
                 // Normal Mode Columns
                 Item {
-                    visible: !root.isTrash
+                    visible: !root.isTrash && AppController.showSizeColumn
                     Layout.preferredWidth: 100
                     implicitHeight: parent.height
 
@@ -214,7 +214,7 @@ Item {
                 }
 
                 Item {
-                    visible: !root.isTrash
+                    visible: !root.isTrash && AppController.showTypeColumn
                     Layout.preferredWidth: 150
                     implicitHeight: parent.height
 
@@ -252,7 +252,7 @@ Item {
                 }
 
                 Item {
-                    visible: !root.isTrash
+                    visible: !root.isTrash && AppController.showDateColumn
                     Layout.preferredWidth: 140
                     implicitHeight: parent.height
 
@@ -290,7 +290,7 @@ Item {
                 }
 
                 Item {
-                    visible: !root.isTrash
+                    visible: !root.isTrash && AppController.showPermissionsColumn
                     Layout.preferredWidth: 90
                     implicitHeight: parent.height
 
@@ -746,7 +746,7 @@ Item {
 
                     // Normal Mode Details
                     StyledText {
-                        visible: !root.isTrash
+                        visible: !root.isTrash && AppController.showSizeColumn
                         Layout.preferredWidth: 100
                         text: rowItem.modelData ? (rowItem.modelData.isDir ? "" : rowItem.modelData.formattedSize) : ""
                         color: Colours.palette.m3onSurfaceVariant
@@ -754,7 +754,7 @@ Item {
                     }
 
                     StyledText {
-                        visible: !root.isTrash
+                        visible: !root.isTrash && AppController.showTypeColumn
                         Layout.preferredWidth: 150
                         text: rowItem.modelData ? rowItem.modelData.mimeDescription : ""
                         color: Colours.palette.m3onSurfaceVariant
@@ -763,7 +763,7 @@ Item {
                     }
 
                     StyledText {
-                        visible: !root.isTrash
+                        visible: !root.isTrash && AppController.showDateColumn
                         Layout.preferredWidth: 140
                         text: rowItem.modelData ? rowItem.modelData.formattedDate : ""
                         color: Colours.palette.m3onSurfaceVariant
@@ -771,7 +771,7 @@ Item {
                     }
 
                     StyledText {
-                        visible: !root.isTrash
+                        visible: !root.isTrash && AppController.showPermissionsColumn
                         Layout.preferredWidth: 90
                         text: rowItem.modelData ? rowItem.modelData.permissions : ""
                         color: Colours.palette.m3outline

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -18,6 +18,10 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+    m_showSizeColumn = settings.value("preferences/showSizeColumn", true).toBool();
+    m_showTypeColumn = settings.value("preferences/showTypeColumn", true).toBool();
+    m_showDateColumn = settings.value("preferences/showDateColumn", true).toBool();
+    m_showPermissionsColumn = settings.value("preferences/showPermissionsColumn", true).toBool();
 }
 
 AppController* AppController::instance() {
@@ -57,6 +61,42 @@ void AppController::setDirectoryOnly(bool dirOnly) {
     if (m_directoryOnly != dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
+    }
+}
+
+void AppController::setShowSizeColumn(bool show) {
+    if (m_showSizeColumn != show) {
+        m_showSizeColumn = show;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/showSizeColumn", show);
+        emit showSizeColumnChanged();
+    }
+}
+
+void AppController::setShowTypeColumn(bool show) {
+    if (m_showTypeColumn != show) {
+        m_showTypeColumn = show;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/showTypeColumn", show);
+        emit showTypeColumnChanged();
+    }
+}
+
+void AppController::setShowDateColumn(bool show) {
+    if (m_showDateColumn != show) {
+        m_showDateColumn = show;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/showDateColumn", show);
+        emit showDateColumnChanged();
+    }
+}
+
+void AppController::setShowPermissionsColumn(bool show) {
+    if (m_showPermissionsColumn != show) {
+        m_showPermissionsColumn = show;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/showPermissionsColumn", show);
+        emit showPermissionsColumnChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -19,6 +19,10 @@ class AppController : public QObject {
     Q_PROPERTY(QStringList filters READ filters WRITE setFilters NOTIFY filtersChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+    Q_PROPERTY(bool showSizeColumn READ showSizeColumn WRITE setShowSizeColumn NOTIFY showSizeColumnChanged)
+    Q_PROPERTY(bool showTypeColumn READ showTypeColumn WRITE setShowTypeColumn NOTIFY showTypeColumnChanged)
+    Q_PROPERTY(bool showDateColumn READ showDateColumn WRITE setShowDateColumn NOTIFY showDateColumnChanged)
+    Q_PROPERTY(bool showPermissionsColumn READ showPermissionsColumn WRITE setShowPermissionsColumn NOTIFY showPermissionsColumnChanged)
     Q_PROPERTY(bool singleClick READ singleClick WRITE setSingleClick NOTIFY singleClickChanged)
     Q_PROPERTY(QString defaultStartupDirectory READ defaultStartupDirectory WRITE setDefaultStartupDirectory NOTIFY defaultStartupDirectoryChanged)
     Q_PROPERTY(int defaultViewMode READ defaultViewMode WRITE setDefaultViewMode NOTIFY defaultViewModeChanged)
@@ -53,6 +57,14 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    [[nodiscard]] bool showSizeColumn() const { return m_showSizeColumn; }
+    void setShowSizeColumn(bool show);
+    [[nodiscard]] bool showTypeColumn() const { return m_showTypeColumn; }
+    void setShowTypeColumn(bool show);
+    [[nodiscard]] bool showDateColumn() const { return m_showDateColumn; }
+    void setShowDateColumn(bool show);
+    [[nodiscard]] bool showPermissionsColumn() const { return m_showPermissionsColumn; }
+    void setShowPermissionsColumn(bool show);
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }
@@ -88,6 +100,10 @@ signals:
     void filtersChanged();
     void directoryOnlyChanged();
     void showHiddenChanged();
+    void showSizeColumnChanged();
+    void showTypeColumnChanged();
+    void showDateColumnChanged();
+    void showPermissionsColumnChanged();
     void singleClickChanged();
     void defaultStartupDirectoryChanged();
     void defaultViewModeChanged();
@@ -107,6 +123,10 @@ private:
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
     bool m_showHidden = false;
+    bool m_showSizeColumn = true;
+    bool m_showTypeColumn = true;
+    bool m_showDateColumn = true;
+    bool m_showPermissionsColumn = true;
     bool m_singleClick = false;
     QString m_defaultStartupDirectory = "home";
     int m_defaultViewMode = 0; // Grid, Details, Compact


### PR DESCRIPTION
## Problem

The details view has a fixed set of columns — name, size, type, date modified, permissions — and no way to hide any of them. In a narrow window or a split pane the four fixed-width columns take 480 px before the name column gets anything, and permissions in particular is rarely what someone is scanning for.

## Change

A preference per column under View & Sorting. Header cells and row cells are bound to the same setting, so they hide together and the grid stays aligned.

All four default to on, so the view is unchanged until configured. The name column is not offered as an option since a listing without it has no use, and the UI says so.

The trash view keeps its own columns, original path and deletion time, unaffected by these settings.

## Scope

This covers *which* columns are shown. Reordering and resizing are deliberately left out: both need the header and the rows rebuilt as a data-driven layout instead of the two hand-written blocks they are today, which is a much larger diff and a separate change.
