### PR TITLE
fix: stop the name column from collapsing in narrow windows

### DIFF
--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -139,7 +139,9 @@ Item {
                 // Name Column
                 Item {
                     Layout.fillWidth: true
+                    Layout.minimumWidth: 120
                     implicitHeight: parent.height
+                    clip: true
 
                     RowLayout {
                         anchors.verticalCenter: parent.verticalCenter
@@ -687,6 +689,7 @@ Item {
                     // Name + Icon + Symlink / Lock
                     RowLayout {
                         Layout.fillWidth: true
+                        Layout.minimumWidth: 120
                         spacing: Tokens.spacing.small
 
                         Item {


### PR DESCRIPTION
## Problem

The name column fills whatever the fixed columns leave over and has no lower bound. The four fixed columns take 480 px, so in a narrow window or a split pane the name column shrinks to nothing and the file names disappear entirely — only the icons remain. The header cell is not clipped either, so "Name" is drawn on top of "Size".

## Change

Give the name column a minimum width of 120 px in both the header and the rows, and clip the header cell so its label cannot bleed into the next column.

When the window is too narrow for everything, the trailing columns are cut off at the edge instead of the names being lost. That is the right way round: a listing without file names is useless, one without the permissions column is not.
