### PR TITLE
feat: scroll the details view horizontally when columns do not fit

### DIFF
--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -117,10 +117,26 @@ Item {
         listView.forceActiveFocus();
     }
 
-    ColumnLayout {
+    Flickable {
+        id: hScroll
+
         z: 1
         anchors.fill: parent
-        anchors.margins: Tokens.padding.small
+        clip: true
+        flickableDirection: Flickable.HorizontalFlick
+        boundsBehavior: Flickable.StopAtBounds
+        contentWidth: Math.max(width, headerRow.implicitWidth + Tokens.padding.medium * 2 + Tokens.padding.small * 2)
+        contentHeight: height
+
+        ScrollBar.horizontal: StyledScrollBar {
+            flickable: hScroll
+        }
+
+    ColumnLayout {
+        x: Tokens.padding.small
+        y: Tokens.padding.small
+        width: hScroll.contentWidth - Tokens.padding.small * 2
+        height: hScroll.height - Tokens.padding.small * 2
         spacing: Tokens.spacing.extraSmall
 
         // Header Row
@@ -131,6 +147,8 @@ Item {
             color: Colours.tPalette.m3surfaceContainerHigh
 
             RowLayout {
+                id: headerRow
+
                 anchors.fill: parent
                 anchors.leftMargin: Tokens.padding.medium
                 anchors.rightMargin: Tokens.padding.medium
@@ -798,6 +816,7 @@ Item {
                 }
             }
         }
+    }
     }
 
     // Background Mouse Area for Deselection, Context Menu on empty space, and Rubber Band Selection


### PR DESCRIPTION
## Problem

When the details view runs out of width it simply clips. Whatever does not fit is unreachable — there is no way to see the permissions column in a split pane, for instance.

## Change

Wrap the header and the list in a horizontal `Flickable` with a `StyledScrollBar`, so the whole table scrolls together and every column stays reachable.

`contentWidth` is derived from `headerRow.implicitWidth` rather than a computed sum of the column widths. That way it stays correct on its own if columns are added, removed or hidden, instead of duplicating the width constants in a second place that has to be kept in sync.

## Notes

Nested flickables are usually a source of trouble, but the list here is already `interactive: false` and driven by a `WheelHandler`, so it never competes with the outer one for drags. Vertical scrolling is unaffected and the horizontal position does not jump.

The rubber band selection sits outside the flickable and is unchanged.
