### PR TITLE
feat: let the details view columns be resized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ qt_add_qml_module(prism_app
         qml/components/views/FileCompactView.qml
         qml/components/views/SplitViewContainer.qml
         qml/components/views/EmptyStateView.qml
+        qml/components/views/ColumnResizeHandle.qml
         qml/components/menus/ContextMenu.qml
         qml/components/menus/TabContextMenu.qml
         qml/components/menus/PlaceContextMenu.qml

--- a/qml/components/views/ColumnResizeHandle.qml
+++ b/qml/components/views/ColumnResizeHandle.qml
@@ -1,0 +1,54 @@
+import QtQuick
+import "../"
+import prism
+
+Item {
+    id: root
+
+    property string columnKey: ""
+    property int defaultWidth: 100
+
+    anchors.right: parent.left
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    width: Tokens.spacing.small
+    z: 5
+
+    Rectangle {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        width: 1
+        height: parent.height * 0.5
+        color: drag.containsMouse || drag.pressed
+            ? Colours.palette.m3primary
+            : Qt.alpha(Colours.palette.m3outlineVariant, 0.6)
+    }
+
+    MouseArea {
+        id: drag
+
+        property real originX: 0
+        property int originWidth: 0
+
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.SplitHCursor
+        preventStealing: true
+
+        onPressed: event => {
+            originX = mapToItem(null, event.x, 0).x;
+            originWidth = AppController.detailsColumnWidths[root.columnKey] !== undefined
+                ? AppController.detailsColumnWidths[root.columnKey]
+                : root.defaultWidth;
+        }
+
+        onPositionChanged: event => {
+            if (!pressed)
+                return;
+            const delta = mapToItem(null, event.x, 0).x - originX;
+            AppController.setDetailsColumnWidth(root.columnKey, Math.round(originWidth - delta));
+        }
+
+        onDoubleClicked: AppController.setDetailsColumnWidth(root.columnKey, root.defaultWidth)
+    }
+}

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -117,6 +117,11 @@ Item {
         listView.forceActiveFocus();
     }
 
+    function colWidth(key, fallback) {
+        const stored = AppController.detailsColumnWidths[key];
+        return stored !== undefined ? stored : fallback;
+    }
+
     ColumnLayout {
         z: 1
         anchors.fill: parent
@@ -144,12 +149,15 @@ Item {
                     RowLayout {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.right: parent.right
                         spacing: 4
 
                         StyledText {
+                            Layout.fillWidth: true
                             text: qsTr("Name")
                             font: Tokens.font.label.medium
                             color: Colours.palette.m3onSurface
+                            elide: Text.ElideRight
                         }
 
                         MaterialIcon {
@@ -177,18 +185,26 @@ Item {
                 // Normal Mode Columns
                 Item {
                     visible: !root.isTrash
-                    Layout.preferredWidth: 100
+                    Layout.preferredWidth: root.colWidth("size", 100)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "size"
+                        defaultWidth: 100
+                    }
 
                     RowLayout {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.right: parent.right
                         spacing: 4
 
                         StyledText {
+                            Layout.fillWidth: true
                             text: qsTr("Size")
                             font: Tokens.font.label.medium
                             color: Colours.palette.m3onSurface
+                            elide: Text.ElideRight
                         }
 
                         MaterialIcon {
@@ -215,18 +231,26 @@ Item {
 
                 Item {
                     visible: !root.isTrash
-                    Layout.preferredWidth: 150
+                    Layout.preferredWidth: root.colWidth("type", 150)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "type"
+                        defaultWidth: 150
+                    }
 
                     RowLayout {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.right: parent.right
                         spacing: 4
 
                         StyledText {
+                            Layout.fillWidth: true
                             text: qsTr("Type")
                             font: Tokens.font.label.medium
                             color: Colours.palette.m3onSurface
+                            elide: Text.ElideRight
                         }
 
                         MaterialIcon {
@@ -253,18 +277,26 @@ Item {
 
                 Item {
                     visible: !root.isTrash
-                    Layout.preferredWidth: 140
+                    Layout.preferredWidth: root.colWidth("date", 140)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "date"
+                        defaultWidth: 140
+                    }
 
                     RowLayout {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.right: parent.right
                         spacing: 4
 
                         StyledText {
+                            Layout.fillWidth: true
                             text: qsTr("Date Modified")
                             font: Tokens.font.label.medium
                             color: Colours.palette.m3onSurface
+                            elide: Text.ElideRight
                         }
 
                         MaterialIcon {
@@ -291,23 +323,35 @@ Item {
 
                 Item {
                     visible: !root.isTrash
-                    Layout.preferredWidth: 90
+                    Layout.preferredWidth: root.colWidth("perms", 90)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "perms"
+                        defaultWidth: 90
+                    }
 
                     StyledText {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.right: parent.right
                         text: qsTr("Permissions")
                         font: Tokens.font.label.medium
                         color: Colours.palette.m3onSurfaceVariant
+                        elide: Text.ElideRight
                     }
                 }
 
                 // Trash Mode Columns
                 Item {
                     visible: root.isTrash
-                    Layout.preferredWidth: 320
+                    Layout.preferredWidth: root.colWidth("origPath", 320)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "origPath"
+                        defaultWidth: 320
+                    }
 
                     StyledText {
                         anchors.verticalCenter: parent.verticalCenter
@@ -315,13 +359,20 @@ Item {
                         text: qsTr("Original Path")
                         font: Tokens.font.label.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        width: parent.width
                     }
                 }
 
                 Item {
                     visible: root.isTrash
-                    Layout.preferredWidth: 180
+                    Layout.preferredWidth: root.colWidth("deleted", 180)
                     implicitHeight: parent.height
+
+                    ColumnResizeHandle {
+                        columnKey: "deleted"
+                        defaultWidth: 180
+                    }
 
                     StyledText {
                         anchors.verticalCenter: parent.verticalCenter
@@ -329,6 +380,8 @@ Item {
                         text: qsTr("Deletion Time")
                         font: Tokens.font.label.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
+                        width: parent.width
                     }
                 }
             }
@@ -747,15 +800,16 @@ Item {
                     // Normal Mode Details
                     StyledText {
                         visible: !root.isTrash
-                        Layout.preferredWidth: 100
+                        Layout.preferredWidth: root.colWidth("size", 100)
                         text: rowItem.modelData ? (rowItem.modelData.isDir ? "" : rowItem.modelData.formattedSize) : ""
                         color: Colours.palette.m3onSurfaceVariant
                         font: Tokens.font.body.small
+                        elide: Text.ElideRight
                     }
 
                     StyledText {
                         visible: !root.isTrash
-                        Layout.preferredWidth: 150
+                        Layout.preferredWidth: root.colWidth("type", 150)
                         text: rowItem.modelData ? rowItem.modelData.mimeDescription : ""
                         color: Colours.palette.m3onSurfaceVariant
                         font: Tokens.font.body.small
@@ -764,24 +818,26 @@ Item {
 
                     StyledText {
                         visible: !root.isTrash
-                        Layout.preferredWidth: 140
+                        Layout.preferredWidth: root.colWidth("date", 140)
                         text: rowItem.modelData ? rowItem.modelData.formattedDate : ""
                         color: Colours.palette.m3onSurfaceVariant
                         font: Tokens.font.body.small
+                        elide: Text.ElideRight
                     }
 
                     StyledText {
                         visible: !root.isTrash
-                        Layout.preferredWidth: 90
+                        Layout.preferredWidth: root.colWidth("perms", 90)
                         text: rowItem.modelData ? rowItem.modelData.permissions : ""
                         color: Colours.palette.m3outline
                         font: Tokens.font.mono.small
+                        elide: Text.ElideRight
                     }
 
                     // Trash Mode Details
                     StyledText {
                         visible: root.isTrash
-                        Layout.preferredWidth: 320
+                        Layout.preferredWidth: root.colWidth("origPath", 320)
                         text: rowItem.modelData ? (rowItem.modelData.originalPath || "") : ""
                         color: Colours.palette.m3onSurfaceVariant
                         font: Tokens.font.body.small
@@ -790,10 +846,11 @@ Item {
 
                     StyledText {
                         visible: root.isTrash
-                        Layout.preferredWidth: 180
+                        Layout.preferredWidth: root.colWidth("deleted", 180)
                         text: rowItem.modelData ? (rowItem.modelData.deletionTime || rowItem.modelData.formattedDate) : ""
                         color: Colours.palette.m3onSurfaceVariant
                         font: Tokens.font.body.small
+                        elide: Text.ElideRight
                     }
                 }
             }

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -1,4 +1,6 @@
 #include "appcontroller.hpp"
+#include <QJsonObject>
+#include <QJsonDocument>
 #include "iconprovider.hpp"
 #include <QSettings>
 #include <iostream>
@@ -18,6 +20,11 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+
+    const QByteArray widthsJson = settings.value("preferences/detailsColumnWidths").toString().toUtf8();
+    if (!widthsJson.isEmpty()) {
+        m_detailsColumnWidths = QJsonDocument::fromJson(widthsJson).object().toVariantMap();
+    }
 }
 
 AppController* AppController::instance() {
@@ -58,6 +65,30 @@ void AppController::setDirectoryOnly(bool dirOnly) {
         m_directoryOnly = dirOnly;
         emit directoryOnlyChanged();
     }
+}
+
+void AppController::setDetailsColumnWidth(const QString& key, int width) {
+    const int clamped = qBound(48, width, 800);
+    if (m_detailsColumnWidths.value(key).toInt() == clamped)
+        return;
+
+    m_detailsColumnWidths.insert(key, clamped);
+
+    QSettings settings("prism", "prism");
+    settings.setValue("preferences/detailsColumnWidths",
+                      QString::fromUtf8(QJsonDocument(QJsonObject::fromVariantMap(m_detailsColumnWidths)).toJson(QJsonDocument::Compact)));
+    emit detailsColumnWidthsChanged();
+}
+
+void AppController::resetDetailsColumnWidths() {
+    if (m_detailsColumnWidths.isEmpty())
+        return;
+
+    m_detailsColumnWidths.clear();
+
+    QSettings settings("prism", "prism");
+    settings.remove("preferences/detailsColumnWidths");
+    emit detailsColumnWidthsChanged();
 }
 
 void AppController::setShowHidden(bool show) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QVariantMap>
 #include <QString>
 #include <QStringList>
 #include <QGuiApplication>
@@ -19,6 +20,7 @@ class AppController : public QObject {
     Q_PROPERTY(QStringList filters READ filters WRITE setFilters NOTIFY filtersChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
+    Q_PROPERTY(QVariantMap detailsColumnWidths READ detailsColumnWidths NOTIFY detailsColumnWidthsChanged)
     Q_PROPERTY(bool singleClick READ singleClick WRITE setSingleClick NOTIFY singleClickChanged)
     Q_PROPERTY(QString defaultStartupDirectory READ defaultStartupDirectory WRITE setDefaultStartupDirectory NOTIFY defaultStartupDirectoryChanged)
     Q_PROPERTY(int defaultViewMode READ defaultViewMode WRITE setDefaultViewMode NOTIFY defaultViewModeChanged)
@@ -53,6 +55,9 @@ public:
     void setDirectoryOnly(bool dirOnly);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
+    [[nodiscard]] QVariantMap detailsColumnWidths() const { return m_detailsColumnWidths; }
+    Q_INVOKABLE void setDetailsColumnWidth(const QString& key, int width);
+    Q_INVOKABLE void resetDetailsColumnWidths();
     void setShowHidden(bool show);
 
     [[nodiscard]] bool singleClick() const { return m_singleClick; }
@@ -88,6 +93,7 @@ signals:
     void filtersChanged();
     void directoryOnlyChanged();
     void showHiddenChanged();
+    void detailsColumnWidthsChanged();
     void singleClickChanged();
     void defaultStartupDirectoryChanged();
     void defaultViewModeChanged();
@@ -107,6 +113,7 @@ private:
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
     bool m_showHidden = false;
+    QVariantMap m_detailsColumnWidths;
     bool m_singleClick = false;
     QString m_defaultStartupDirectory = "home";
     int m_defaultViewMode = 0; // Grid, Details, Compact


### PR DESCRIPTION
## Problem

Details view column widths are hardcoded. A long MIME description gets 150 px whatever it needs, a date format that does not fit is simply cut, and permissions keeps 90 px that most people never read.

## Change

A drag handle sits in the 8 px gap to the left of each column, so it never covers the first characters of the header label. Dragging left widens the column, dragging right narrows it. Double clicking a handle restores that column's default width.

Widths are stored per column key as JSON under `preferences/detailsColumnWidths`, and clamped to 48–800 px so a column cannot be dragged to nothing or blow up the layout. Only columns that were actually resized are written, so an untouched install keeps the built-in defaults and stores nothing.

## Overflow

Making widths adjustable exposed that the cells never bounded their content: a narrowed column simply drew over its neighbour. Both halves are fixed here.

Header labels are now anchored to their cell's right edge and elide, rather than being clipped. Clipping cuts a glyph in half with no indication; eliding shows that something was left out. This covers all seven labels including permissions and the two trash columns, which are built differently from the sortable ones.

Four row cells — size, date, permissions and deletion time — had no elide either and now do.

## Scope

This is resizing only. Reordering columns needs the header and rows rebuilt as a data-driven layout instead of two hand-written blocks, which is a much larger change and belongs on its own.
