### PR TITLE
fix: give the manage places and devices rows real vertical padding

### DIFF
--- a/qml/components/dialogs/PlacesManageModal.qml
+++ b/qml/components/dialogs/PlacesManageModal.qml
@@ -175,8 +175,8 @@ MouseArea {
                                     required property bool isCustom
 
                                     width: placesList.width
-                                    height: 46
-                                    implicitHeight: 46
+                                    height: implicitHeight
+                                    implicitHeight: Math.max(46, placeTextCol.implicitHeight + Tokens.padding.extraSmall * 2)
                                     radius: Tokens.rounding.medium
                                     color: rowHoverArea.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer
 
@@ -325,7 +325,7 @@ MouseArea {
                                         anchors.right: placeActions.left
                                         anchors.rightMargin: Tokens.spacing.small
                                         anchors.verticalCenter: parent.verticalCenter
-                                        spacing: 0
+                                        spacing: 2
 
                                         StyledText {
                                             width: parent.width
@@ -388,8 +388,8 @@ MouseArea {
                                     required property var modelData
 
                                     width: devicesList.width
-                                    height: 46
-                                    implicitHeight: 46
+                                    height: implicitHeight
+                                    implicitHeight: Math.max(46, devTextCol.implicitHeight + Tokens.padding.extraSmall * 2)
                                     radius: Tokens.rounding.medium
                                     color: devHoverArea.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer
 
@@ -445,7 +445,7 @@ MouseArea {
                                         anchors.right: visBtn.left
                                         anchors.rightMargin: Tokens.spacing.small
                                         anchors.verticalCenter: parent.verticalCenter
-                                        spacing: 0
+                                        spacing: 2
 
                                         StyledText {
                                             width: parent.width


### PR DESCRIPTION
## Problem

Reported as inconsistent padding between the entries in Places & Devices: some rows look correctly spaced, others cramped.

Measuring it, the rows are laid out identically. In every card the first label starts 6 px down and the second 31 px down. What differs is the ink: `/dev/sda3 → /run/media/dim/BA4803C348037CFF` is set in capitals and digits that reach about 2 px higher than the lowercase of `/dev/sda1 (unmounted)`, so the gap above it looks smaller.

That difference only became visible because there is no room to absorb it. Both delegates pin the row to 46 px, while the two labels measure 22 px and 21 px, so the text block is 43 px and sits in the card with one and a half pixels above and below.

## Change

Derive the row height from the labels rather than hardcoding it, with 46 px kept as a floor so nothing shrinks below what the action buttons need, and put a small gap between the two lines.

Applied to both the places and the devices delegate, which had the same geometry.

## Note

The hardcoded height was also a clipping hazard. `Tokens` exposes a font scale, and at a larger setting the two labels already exceed 46 px, with no way for the card to follow. Measuring the content fixes that at the same time.
