### PR TITLE
feat: handle the trash on every volume, not just the one in home

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ qt_add_executable(prism_app
     src/controllers/tabmanager.cpp
     src/core/fileutils.hpp
     src/core/fileutils.cpp
+    src/core/trashlocations.hpp
+    src/core/trashlocations.cpp
     src/core/fileoperations.hpp
     src/core/fileoperations.cpp
     src/core/catboxuploader.hpp

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -1,4 +1,5 @@
 #include "fileoperations.hpp"
+#include "trashlocations.hpp"
 
 #include "catboxuploader.hpp"
 #include <QDir>
@@ -429,13 +430,6 @@ void FileOperations::moveToTrash(const QStringList& paths) {
     m_progress->setStatusText(tr("Moving to trash..."));
 
     (void)QtConcurrent::run([this, paths]() {
-        QString trashDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/Trash";
-        QString filesDir = trashDir + "/files";
-        QString infoDir = trashDir + "/info";
-
-        QDir().mkpath(filesDir);
-        QDir().mkpath(infoDir);
-
         bool allSuccess = true;
 
         for (const QString& p : paths) {
@@ -443,23 +437,34 @@ void FileOperations::moveToTrash(const QStringList& paths) {
             if (!fi.exists())
                 continue;
 
+            const TrashLocation location = TrashLocations::forSourceFile(fi.absoluteFilePath(), true);
+            if (!location.isValid()) {
+                allSuccess = false;
+                continue;
+            }
+
             QString fileName = fi.fileName();
-            QString destFile = filesDir + "/" + fileName;
-            QString infoFile = infoDir + "/" + fileName + ".trashinfo";
+            QString destFile = location.filesDir + "/" + fileName;
+            QString infoFile = location.infoDir + "/" + fileName + ".trashinfo";
 
             int counter = 1;
             while (QFile::exists(destFile) || QFile::exists(infoFile)) {
                 QString uniqueName = QString("%1.%2").arg(fileName, QString::number(counter++));
-                destFile = filesDir + "/" + uniqueName;
-                infoFile = infoDir + "/" + uniqueName + ".trashinfo";
+                destFile = location.filesDir + "/" + uniqueName;
+                infoFile = location.infoDir + "/" + uniqueName + ".trashinfo";
             }
 
             // Write trashinfo
             QFile info(infoFile);
             if (info.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QString deletionDate = QDateTime::currentDateTime().toString(Qt::ISODate);
-                const QString encodedPath =
-                    QString::fromLatin1(QUrl::toPercentEncoding(fi.absoluteFilePath(), "/"));
+                QString originalPath = fi.absoluteFilePath();
+                if (!location.topDir.isEmpty()) {
+                    const QString prefix = QDir::cleanPath(location.topDir) + "/";
+                    if (originalPath.startsWith(prefix))
+                        originalPath = originalPath.mid(prefix.size());
+                }
+                const QString encodedPath = QString::fromLatin1(QUrl::toPercentEncoding(originalPath, "/"));
                 QString content = QString("[Trash Info]\nPath=%1\nDeletionDate=%2\n").arg(encodedPath, deletionDate);
                 info.write(content.toUtf8());
                 info.close();
@@ -488,21 +493,18 @@ void FileOperations::moveToTrash(const QStringList& paths) {
 }
 
 void FileOperations::restoreFromTrash(const QString& targetPath) {
-    QString trashDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/Trash";
-    QString infoPath = targetPath;
     QString trashedFile = targetPath;
-
-    if (targetPath.contains("/Trash/files/")) {
-        QString name = QFileInfo(targetPath).fileName();
-        infoPath = trashDir + "/info/" + name + ".trashinfo";
-        trashedFile = targetPath;
-    } else if (targetPath.endsWith(".trashinfo")) {
-        QString baseName = QFileInfo(targetPath).completeBaseName();
-        trashedFile = trashDir + "/files/" + baseName;
+    if (targetPath.endsWith(".trashinfo")) {
+        const QString baseDir = QFileInfo(QFileInfo(targetPath).absolutePath()).absolutePath();
+        trashedFile = baseDir + "/files/" + QFileInfo(targetPath).completeBaseName();
     }
 
-    QFileInfo fi(infoPath);
-    if (!fi.exists())
+    const TrashLocation location = TrashLocations::forTrashedFile(trashedFile);
+    if (!location.isValid())
+        return;
+
+    const QString infoPath = location.infoDir + "/" + QFileInfo(trashedFile).fileName() + ".trashinfo";
+    if (!QFileInfo::exists(infoPath))
         return;
 
     QFile file(infoPath);
@@ -513,7 +515,7 @@ void FileOperations::restoreFromTrash(const QString& targetPath) {
     while (!file.atEnd()) {
         QString line = QString::fromUtf8(file.readLine()).trimmed();
         if (line.startsWith("Path=")) {
-            origPath = QUrl::fromPercentEncoding(line.mid(5).toUtf8());
+            origPath = TrashLocations::resolveOriginalPath(location, line.mid(5));
             break;
         }
     }
@@ -537,10 +539,6 @@ void FileOperations::emptyTrash() {
     m_progress->setStatusText(tr("Emptying trash..."));
 
     (void)QtConcurrent::run([this]() {
-        QString trashDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/Trash";
-        QString filesDir = trashDir + "/files";
-        QString infoDir = trashDir + "/info";
-
         bool allSuccess = true;
 
         auto removeDirContents = [this, &allSuccess](const QString& dirPath) {
@@ -561,12 +559,14 @@ void FileOperations::emptyTrash() {
             }
         };
 
-        removeDirContents(filesDir);
-        removeDirContents(infoDir);
+        const auto locations = TrashLocations::all();
+        for (const auto& location : locations) {
+            removeDirContents(location.filesDir);
+            removeDirContents(location.infoDir);
+        }
 
-        // Ensure directories still exist
-        QDir().mkpath(filesDir);
-        QDir().mkpath(infoDir);
+        QDir().mkpath(TrashLocations::homeTrashFilesDir());
+        QDir().mkpath(TrashLocations::homeTrashDir() + "/info");
 
         QMetaObject::invokeMethod(this, [this, allSuccess]() {
             m_progress->setRunning(false);

--- a/src/core/trashlocations.cpp
+++ b/src/core/trashlocations.cpp
@@ -1,0 +1,164 @@
+#include "trashlocations.hpp"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QStorageInfo>
+#include <QUrl>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace prism::core {
+
+QString TrashLocations::homeTrashDir() {
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/Trash");
+}
+
+QString TrashLocations::homeTrashFilesDir() {
+    return homeTrashDir() + QStringLiteral("/files");
+}
+
+bool TrashLocations::isTrashRoot(const QString& path) {
+    if (path.isEmpty())
+        return false;
+    return QDir::cleanPath(path) == QDir::cleanPath(homeTrashFilesDir());
+}
+
+QString TrashLocations::topDirFor(const QString& path) {
+    const QStorageInfo storage(QFileInfo(path).absolutePath());
+    return storage.isValid() ? storage.rootPath() : QString();
+}
+
+QStringList TrashLocations::mountPoints() {
+    QStringList roots;
+    const QString homeRoot = QStorageInfo(QDir::homePath()).rootPath();
+
+    const auto volumes = QStorageInfo::mountedVolumes();
+    for (const QStorageInfo& volume : volumes) {
+        if (!volume.isValid() || !volume.isReady() || volume.isReadOnly())
+            continue;
+
+        const QString root = volume.rootPath();
+        if (root.isEmpty() || root == homeRoot || roots.contains(root))
+            continue;
+
+        const QByteArray fsType = volume.fileSystemType();
+        if (fsType == "proc" || fsType == "sysfs" || fsType == "devtmpfs" || fsType == "cgroup2"
+            || fsType == "securityfs" || fsType == "debugfs" || fsType == "tracefs" || fsType == "configfs"
+            || fsType == "pstore" || fsType == "bpf" || fsType == "efivarfs" || fsType == "mqueue"
+            || fsType == "hugetlbfs" || fsType == "fusectl" || fsType == "binfmt_misc" || fsType == "autofs"
+            || fsType == "ramfs" || fsType == "squashfs" || fsType == "overlay" || fsType == "tmpfs")
+            continue;
+
+        roots.append(root);
+    }
+
+    return roots;
+}
+
+static TrashLocation makeLocation(const QString& baseDir, const QString& topDir) {
+    TrashLocation location;
+    location.baseDir = baseDir;
+    location.filesDir = baseDir + QStringLiteral("/files");
+    location.infoDir = baseDir + QStringLiteral("/info");
+    location.topDir = topDir;
+    return location;
+}
+
+static bool isStickyDirectory(const QString& path) {
+    struct stat info;
+    if (lstat(QFile::encodeName(path).constData(), &info) != 0)
+        return false;
+    if (S_ISLNK(info.st_mode) || !S_ISDIR(info.st_mode))
+        return false;
+    return (info.st_mode & S_ISVTX) != 0;
+}
+
+static TrashLocation volumeTrash(const QString& topDir, bool create) {
+    const QString uid = QString::number(::getuid());
+
+    const QString shared = topDir + QStringLiteral("/.Trash");
+    if (isStickyDirectory(shared)) {
+        const QString base = shared + QLatin1Char('/') + uid;
+        if (QDir(base).exists() || (create && QDir().mkpath(base + QStringLiteral("/files")) && QDir().mkpath(base + QStringLiteral("/info"))))
+            return makeLocation(base, topDir);
+    }
+
+    const QString personal = topDir + QStringLiteral("/.Trash-") + uid;
+    if (QDir(personal).exists())
+        return makeLocation(personal, topDir);
+
+    if (create && QDir().mkpath(personal + QStringLiteral("/files")) && QDir().mkpath(personal + QStringLiteral("/info")))
+        return makeLocation(personal, topDir);
+
+    return {};
+}
+
+QList<TrashLocation> TrashLocations::all() {
+    QList<TrashLocation> locations;
+    locations.append(makeLocation(homeTrashDir(), QString()));
+
+    const QStringList roots = mountPoints();
+    for (const QString& root : roots) {
+        const TrashLocation location = volumeTrash(root, false);
+        if (location.isValid())
+            locations.append(location);
+    }
+
+    return locations;
+}
+
+TrashLocation TrashLocations::forTrashedFile(const QString& trashedFilePath) {
+    const QString filesDir = QFileInfo(trashedFilePath).absolutePath();
+    if (QFileInfo(filesDir).fileName() != QLatin1String("files"))
+        return {};
+
+    const QString baseDir = QFileInfo(filesDir).absolutePath();
+    const QString homeBase = QDir::cleanPath(homeTrashDir());
+    if (QDir::cleanPath(baseDir) == homeBase)
+        return makeLocation(baseDir, QString());
+
+    QString topDir = QFileInfo(baseDir).absolutePath();
+    if (QFileInfo(baseDir).fileName() == QLatin1String(".Trash") || QFileInfo(topDir).fileName() == QLatin1String(".Trash"))
+        topDir = QFileInfo(topDir).absolutePath();
+
+    return makeLocation(baseDir, topDir);
+}
+
+TrashLocation TrashLocations::forSourceFile(const QString& sourcePath, bool create) {
+    const QString homeRoot = QStorageInfo(QDir::homePath()).rootPath();
+    const QString sourceRoot = topDirFor(sourcePath);
+
+    if (sourceRoot.isEmpty() || sourceRoot == homeRoot || !mountPoints().contains(sourceRoot)) {
+        const TrashLocation home = makeLocation(homeTrashDir(), QString());
+        if (create) {
+            QDir().mkpath(home.filesDir);
+            QDir().mkpath(home.infoDir);
+        }
+        return home;
+    }
+
+    const TrashLocation location = volumeTrash(sourceRoot, create);
+    if (location.isValid())
+        return location;
+
+    const TrashLocation home = makeLocation(homeTrashDir(), QString());
+    if (create) {
+        QDir().mkpath(home.filesDir);
+        QDir().mkpath(home.infoDir);
+    }
+    return home;
+}
+
+QString TrashLocations::resolveOriginalPath(const TrashLocation& location, const QString& encodedPath) {
+    const QString decoded = QUrl::fromPercentEncoding(encodedPath.toUtf8());
+    if (decoded.isEmpty() || decoded.startsWith(QLatin1Char('/')))
+        return decoded;
+    if (location.topDir.isEmpty())
+        return decoded;
+    return QDir::cleanPath(location.topDir + QLatin1Char('/') + decoded);
+}
+
+} // namespace prism::core

--- a/src/core/trashlocations.hpp
+++ b/src/core/trashlocations.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+
+namespace prism::core {
+
+struct TrashLocation {
+    QString baseDir;
+    QString filesDir;
+    QString infoDir;
+    QString topDir;
+
+    [[nodiscard]] bool isValid() const { return !filesDir.isEmpty(); }
+};
+
+class TrashLocations {
+public:
+    static QString homeTrashDir();
+    static QString homeTrashFilesDir();
+
+    static bool isTrashRoot(const QString& path);
+
+    static QList<TrashLocation> all();
+    static TrashLocation forTrashedFile(const QString& trashedFilePath);
+    static TrashLocation forSourceFile(const QString& sourcePath, bool create);
+
+    static QString resolveOriginalPath(const TrashLocation& location, const QString& encodedPath);
+
+private:
+    static QString topDirFor(const QString& path);
+    static QStringList mountPoints();
+};
+
+} // namespace prism::core

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -1,4 +1,5 @@
 #include "filesystemmodel.hpp"
+#include "../core/trashlocations.hpp"
 #include "../core/fileutils.hpp"
 
 #include <QCollator>
@@ -235,15 +236,16 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
 
     d.hasThumbnail = prism::core::FileUtils::shouldThumbnail(d.isImage, d.isVideo, d.size);
 
-    if (fi.absolutePath().contains("/.local/share/Trash/files") || fi.absolutePath().contains("/Trash/files")) {
+    const prism::core::TrashLocation trashLocation = prism::core::TrashLocations::forTrashedFile(fi.absoluteFilePath());
+    if (trashLocation.isValid()) {
         d.isTrashItem = true;
-        QString infoPath = QDir::homePath() + "/.local/share/Trash/info/" + fi.fileName() + ".trashinfo";
+        QString infoPath = trashLocation.infoDir + "/" + fi.fileName() + ".trashinfo";
         QFile infoFile(infoPath);
         if (infoFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
             while (!infoFile.atEnd()) {
                 QString line = QString::fromUtf8(infoFile.readLine()).trimmed();
                 if (line.startsWith("Path=")) {
-                    d.originalPath = QUrl::fromPercentEncoding(line.mid(5).toUtf8());
+                    d.originalPath = prism::core::TrashLocations::resolveOriginalPath(trashLocation, line.mid(5));
                 } else if (line.startsWith("DeletionDate=")) {
                     QString dStr = line.mid(13);
                     QDateTime dt = QDateTime::fromString(dStr, Qt::ISODate);
@@ -344,7 +346,16 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
         return;
     }
 
-    m_watcher.addPath(m_path);
+    if (prism::core::TrashLocations::isTrashRoot(m_path)) {
+        const auto locations = prism::core::TrashLocations::all();
+        for (const auto& location : locations) {
+            if (QDir(location.filesDir).exists())
+                m_watcher.addPath(location.filesDir);
+        }
+    } else {
+        m_watcher.addPath(m_path);
+    }
+
     QString scanPath = m_path;
 
     if (isPathReset && !m_isLoading) {
@@ -353,8 +364,16 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
     }
 
     (void)QtConcurrent::run([this, scanPath, isPathReset, generationToken, generation]() {
-        QDir dir(scanPath);
-        QFileInfoList list = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
+        const auto filters = QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System;
+
+        QFileInfoList list;
+        if (prism::core::TrashLocations::isTrashRoot(scanPath)) {
+            const auto locations = prism::core::TrashLocations::all();
+            for (const auto& location : locations)
+                list += QDir(location.filesDir).entryInfoList(filters);
+        } else {
+            list = QDir(scanPath).entryInfoList(filters);
+        }
         QMimeDatabase mimeDb;
 
         QList<RawEntryData> rawData;


### PR DESCRIPTION
## Problem

The trash directory was spelled out as the one under the home data location in four separate places: the listing in `FileSystemModel`, `moveToTrash`, `restoreFromTrash` and `emptyTrash`.

Two consequences. Anything deleted on a second drive by another file manager lives in `$topdir/.Trash-$uid` and never appeared in Prism at all. And Prism's own delete was worse than merely incomplete: moving a file from another filesystem into the home trash cannot be a rename, so `QFile::rename` failed and execution fell through to the copy fallback. Deleting a large file off a secondary drive copied every byte into the home partition before removing the original.

The listing had a second defect. It flagged an entry as trashed when its path contained `/Trash/files`, but then looked the `.trashinfo` up in the home trash regardless. Even if a file from another volume had been listed, it would have shown no original path and no deletion date.

## Change

One helper resolves trash locations, following the freedesktop layout: the volume's shared `$topdir/.Trash/$uid` when `$topdir/.Trash` exists as a sticky, non-symlink directory, otherwise `$topdir/.Trash-$uid`, and the home trash for anything on the home filesystem. All four call sites go through it.

Deleting on a volume is a rename again. The trash view lists every trash and watches all of them, so entries other applications put there show up. Emptying clears all of them; restore and the info lookup use the trash the file actually sits in.

`Path=` is written relative to the volume root for a volume trash, as the specification requires, and resolved back against it when reading. This is what makes a restore survive the volume being remounted somewhere else. Absolute paths are still accepted on read, so trashes written by older versions and by other tools keep working.

Pseudo filesystems are skipped when enumerating. `tmpfs` is skipped as well, matching gio, which refuses trash operations on system internal mounts entirely; here such files fall back to the home trash rather than the operation failing.

## An invariant worth naming

`forSourceFile` originally derived the volume through `QStorageInfo` while `all()` filtered the mount list, so the two could disagree and a file could be trashed into a directory the view would never read back. Writing is now restricted to trashes the listing also enumerates.

## Verified

The path logic is covered by a throwaway test binary against a synthetic tree: `.Trash-$uid` and `.Trash/$uid` both resolving to the right info directory and volume root, the home trash reporting no volume root, a normal file resolving to nothing, and `Path=` round-tripping relative, absolute and percent encoded.

The full cycle on real hardware was tested by @eximora-private against a second partition.
