### PR TITLE
feat: rename several files at once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ qt_add_qml_module(prism_app
         qml/components/dialogs/GitModal.qml
         qml/components/dialogs/CompressModal.qml
         qml/components/dialogs/OperationsModal.qml
+        qml/components/dialogs/BulkRenameModal.qml
         qml/components/dialogs/ConfirmDeleteModal.qml
         qml/components/dialogs/VectorBloomOverlay.qml
         qml/components/dialogs/RunnerGameModal.qml

--- a/qml/components/dialogs/BulkRenameModal.qml
+++ b/qml/components/dialogs/BulkRenameModal.qml
@@ -1,0 +1,436 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../"
+import "../controls"
+import prism
+
+MouseArea {
+    id: root
+
+    property bool expanded: false
+    property var targets: []
+
+    property string mode: "replace"
+    property string findText: ""
+    property string replaceText: ""
+    property string pattern: "#"
+    property int startAt: 1
+
+    readonly property var preview: {
+        const result = [];
+        const taken = {};
+        let counter = root.startAt;
+
+        for (let i = 0; i < root.targets.length; i++) {
+            const original = root.targets[i].name;
+            const dot = original.lastIndexOf(".");
+            const isDir = root.targets[i].isDir;
+            const base = (!isDir && dot > 0) ? original.substring(0, dot) : original;
+            const suffix = (!isDir && dot > 0) ? original.substring(dot) : "";
+
+            let name;
+            if (root.mode === "replace") {
+                name = root.findText.length > 0 ? original.split(root.findText).join(root.replaceText) : original;
+            } else {
+                const digits = (root.pattern.match(/#+/) || ["#"])[0];
+                let number = String(counter++);
+                while (number.length < digits.length)
+                    number = "0" + number;
+                name = root.pattern.replace(/#+/, number).split("{name}").join(base) + suffix;
+            }
+
+            name = name.trim();
+
+            let problem = "";
+            if (name.length === 0)
+                problem = qsTr("empty");
+            else if (name.indexOf("/") >= 0)
+                problem = qsTr("contains a slash");
+            else if (taken[name])
+                problem = qsTr("used twice");
+            taken[name] = true;
+
+            result.push({ from: original, to: name, problem: problem, changed: name !== original });
+        }
+        return result;
+    }
+
+    readonly property int changedCount: root.preview.filter(entry => entry.changed && entry.problem.length === 0).length
+    readonly property bool hasProblem: root.preview.some(entry => entry.problem.length > 0)
+
+    signal applied(var names)
+
+    anchors.fill: parent
+    visible: opacity > 0.001
+    enabled: expanded
+    hoverEnabled: expanded
+    cursorShape: expanded ? Qt.ArrowCursor : undefined
+    z: 100
+
+    opacity: expanded ? 1.0 : 0.0
+    Behavior on opacity {
+        Anim {
+            type: Anim.FastEffects
+        }
+    }
+
+    onClicked: root.expanded = false
+    onWheel: wheel => wheel.accepted = true
+
+    Keys.onEscapePressed: root.expanded = false
+
+    onExpandedChanged: {
+        if (expanded) {
+            root.mode = "replace";
+            root.findText = "";
+            root.replaceText = "";
+            root.pattern = "#";
+            root.startAt = 1;
+            findInput.text = "";
+            replaceInput.text = "";
+            patternInput.text = "#";
+            startInput.text = "1";
+            findInput.forceActiveFocus();
+        } else if (typeof splitContainer !== "undefined" && splitContainer) {
+            splitContainer.focusActiveView();
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.alpha(Colours.palette.m3scrim, 0.4)
+    }
+
+    StyledRect {
+        anchors.centerIn: parent
+        width: Math.min(parent.width - 48, 560)
+        height: Math.min(parent.height - 32, modalCol.implicitHeight + Tokens.padding.large * 2)
+        radius: Tokens.rounding.large
+        color: Colours.palette.m3surfaceContainerHigh
+
+        scale: root.expanded ? 1.0 : 0.94
+
+        Behavior on scale {
+            Anim {
+                type: Anim.FastEffects
+                easing: Tokens.anim.standard
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
+        }
+
+        ColumnLayout {
+            id: modalCol
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.large
+            spacing: Tokens.spacing.medium
+
+            RowLayout {
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: "drive_file_rename_outline"
+                    color: Colours.palette.m3primary
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Rename %n item(s)", "", root.targets.length)
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.title.medium
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                Repeater {
+                    model: [
+                        { key: "replace", label: qsTr("Find and Replace") },
+                        { key: "number", label: qsTr("Numbered") }
+                    ]
+
+                    delegate: StyledRect {
+                        id: modeCard
+
+                        required property var modelData
+                        readonly property bool isSelected: root.mode === modelData.key
+
+                        Layout.fillWidth: true
+                        implicitHeight: 40
+                        radius: Tokens.rounding.medium
+                        color: isSelected
+                            ? Colours.palette.m3primaryContainer
+                            : (modeHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
+
+                        StyledText {
+                            anchors.centerIn: parent
+                            text: modeCard.modelData.label
+                            color: modeCard.isSelected ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
+                            font: Tokens.font.label.large
+                        }
+
+                        MouseArea {
+                            id: modeHover
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: root.mode = modeCard.modelData.key
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                visible: root.mode === "replace"
+                spacing: Tokens.spacing.small
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: 42
+                    radius: Tokens.rounding.small
+                    color: Colours.palette.m3surfaceContainerHighest
+                    border.color: findInput.activeFocus ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+                    border.width: findInput.activeFocus ? 2 : 1
+                    clip: true
+
+                    TextInput {
+                        id: findInput
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        verticalAlignment: TextInput.AlignVCenter
+                        color: Colours.palette.m3onSurface
+                        font: Tokens.font.body.medium
+                        selectByMouse: true
+                        onTextChanged: root.findText = text
+
+                        StyledText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            visible: !parent.text
+                            text: qsTr("Find")
+                            color: Colours.palette.m3outline
+                            font: parent.font
+                        }
+                    }
+                }
+
+                MaterialIcon {
+                    text: "arrow_forward"
+                    color: Colours.palette.m3onSurfaceVariant
+                    fontStyle: Tokens.font.icon.small
+                }
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: 42
+                    radius: Tokens.rounding.small
+                    color: Colours.palette.m3surfaceContainerHighest
+                    border.color: replaceInput.activeFocus ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+                    border.width: replaceInput.activeFocus ? 2 : 1
+                    clip: true
+
+                    TextInput {
+                        id: replaceInput
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        verticalAlignment: TextInput.AlignVCenter
+                        color: Colours.palette.m3onSurface
+                        font: Tokens.font.body.medium
+                        selectByMouse: true
+                        onTextChanged: root.replaceText = text
+
+                        StyledText {
+                            anchors.verticalCenter: parent.verticalCenter
+                            visible: !parent.text
+                            text: qsTr("Replace with")
+                            color: Colours.palette.m3outline
+                            font: parent.font
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                visible: root.mode === "number"
+                spacing: Tokens.spacing.small
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    implicitHeight: 42
+                    radius: Tokens.rounding.small
+                    color: Colours.palette.m3surfaceContainerHighest
+                    border.color: patternInput.activeFocus ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+                    border.width: patternInput.activeFocus ? 2 : 1
+                    clip: true
+
+                    TextInput {
+                        id: patternInput
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        text: "#"
+                        verticalAlignment: TextInput.AlignVCenter
+                        color: Colours.palette.m3onSurface
+                        font: Tokens.font.body.medium
+                        selectByMouse: true
+                        onTextChanged: root.pattern = text
+                    }
+                }
+
+                StyledRect {
+                    implicitWidth: 90
+                    implicitHeight: 42
+                    radius: Tokens.rounding.small
+                    color: Colours.palette.m3surfaceContainerHighest
+                    border.color: startInput.activeFocus ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+                    border.width: startInput.activeFocus ? 2 : 1
+                    clip: true
+
+                    TextInput {
+                        id: startInput
+                        anchors.fill: parent
+                        anchors.margins: Tokens.padding.medium
+                        text: "1"
+                        verticalAlignment: TextInput.AlignVCenter
+                        horizontalAlignment: TextInput.AlignHCenter
+                        color: Colours.palette.m3onSurface
+                        font: Tokens.font.body.medium
+                        selectByMouse: true
+                        validator: IntValidator { bottom: 0; top: 999999 }
+                        onTextChanged: root.startAt = parseInt(text) || 0
+                    }
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                visible: root.mode === "number"
+                text: qsTr("# becomes the counter, repeat it to pad with zeros. {name} inserts the current name. The extension is kept.")
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.body.small
+                wrapMode: Text.Wrap
+            }
+
+            StyledRect {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Math.min(220, Math.max(64, root.preview.length * 26 + Tokens.padding.small * 2))
+                radius: Tokens.rounding.medium
+                color: Colours.tPalette.m3surfaceContainer
+                clip: true
+
+                ListView {
+                    id: previewList
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.small
+                    model: root.preview
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    ScrollBar.vertical: StyledScrollBar {
+                        flickable: previewList
+                    }
+
+                    delegate: RowLayout {
+                        required property var modelData
+
+                        width: previewList.width
+                        height: 26
+                        spacing: Tokens.spacing.small
+
+                        StyledText {
+                            Layout.preferredWidth: (parent.width - 40) / 2
+                            text: modelData.from
+                            color: Colours.palette.m3onSurfaceVariant
+                            font: Tokens.font.body.small
+                            elide: Text.ElideMiddle
+                        }
+
+                        MaterialIcon {
+                            text: "arrow_forward"
+                            color: Colours.palette.m3outline
+                            fontStyle: Tokens.font.icon.small
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: modelData.problem.length > 0 ? qsTr("%1 (%2)").arg(modelData.to).arg(modelData.problem) : modelData.to
+                            color: modelData.problem.length > 0
+                                ? Colours.palette.m3error
+                                : (modelData.changed ? Colours.palette.m3primary : Colours.palette.m3outline)
+                            font: Tokens.font.body.small
+                            elide: Text.ElideMiddle
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: root.hasProblem
+                        ? qsTr("Resolve the highlighted names to continue")
+                        : qsTr("%n name(s) will change", "", root.changedCount)
+                    color: root.hasProblem ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
+                    font: Tokens.font.body.small
+                    elide: Text.ElideRight
+                }
+
+                StyledRect {
+                    implicitWidth: 70
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    color: "transparent"
+
+                    StateLayer {
+                        color: Colours.palette.m3onSurface
+                        onClicked: root.expanded = false
+                    }
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: qsTr("Cancel")
+                        color: Colours.palette.m3primary
+                        font: Tokens.font.label.large
+                    }
+                }
+
+                StyledRect {
+                    implicitWidth: 90
+                    implicitHeight: 36
+                    radius: Tokens.rounding.full
+                    opacity: (!root.hasProblem && root.changedCount > 0) ? 1.0 : 0.4
+                    color: Colours.palette.m3primary
+
+                    StateLayer {
+                        color: Colours.palette.m3onPrimary
+                        onClicked: {
+                            if (root.hasProblem || root.changedCount === 0)
+                                return;
+                            root.applied(root.preview.map(entry => entry.to));
+                            root.expanded = false;
+                        }
+                    }
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: qsTr("Rename")
+                        color: Colours.palette.m3onPrimary
+                        font: Tokens.font.label.large
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -333,11 +333,16 @@ ApplicationWindow {
                     let serviceId = action.substring(7);
                     AppIntegration.shareFiles(serviceId, targetPaths);
                 } else if (action === "rename" && item) {
-                    newItemModal.title = qsTr("Rename");
-                    newItemModal.icon = "drive_file_rename_outline";
-                    newItemModal.targetRenamePath = item.path;
-                    newItemModal.initialText = item.name;
-                    newItemModal.expanded = true;
+                    if (targetPaths.length > 1) {
+                        bulkRenameModal.targets = FileUtils.describePaths(targetPaths);
+                        bulkRenameModal.expanded = true;
+                    } else {
+                        newItemModal.title = qsTr("Rename");
+                        newItemModal.icon = "drive_file_rename_outline";
+                        newItemModal.targetRenamePath = item.path;
+                        newItemModal.initialText = item.name;
+                        newItemModal.expanded = true;
+                    }
                 } else if (action === "trash" && item) {
                     FileOperations.moveToTrash(targetPaths);
                 } else if (action === "delete" && item) {
@@ -462,6 +467,11 @@ ApplicationWindow {
         }
 
         // New Item / Rename Modal
+        BulkRenameModal {
+            id: bulkRenameModal
+            onApplied: names => FileOperations.bulkRename(bulkRenameModal.targets.map(entry => entry.path), names)
+        }
+
         NewItemModal {
             id: newItemModal
             onAccepted: text => {

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -593,6 +593,94 @@ void FileOperations::renameFile(const QString& oldPath, const QString& newName) 
     emit operationFinished(success, success ? tr("Renamed successfully") : tr("Rename failed"));
 }
 
+void FileOperations::bulkRename(const QStringList& paths, const QStringList& newNames) {
+    if (paths.isEmpty() || paths.size() != newNames.size()) {
+        emit operationFinished(false, tr("Rename failed"));
+        return;
+    }
+
+    QStringList sources;
+    QStringList targets;
+
+    for (int i = 0; i < paths.size(); ++i) {
+        const QFileInfo fi(paths.at(i));
+        const QString name = newNames.at(i).trimmed();
+
+        if (!fi.exists()) {
+            emit operationFinished(false, tr("Rename failed: %1 no longer exists").arg(fi.fileName()));
+            return;
+        }
+        if (name.isEmpty() || name.contains(QLatin1Char('/'))) {
+            emit operationFinished(false, tr("Rename failed: %1 is not a valid name").arg(name));
+            return;
+        }
+
+        const QString target = fi.absolutePath() + QLatin1Char('/') + name;
+        if (target == fi.absoluteFilePath())
+            continue;
+
+        if (targets.contains(target)) {
+            emit operationFinished(false, tr("Rename failed: %1 would be used twice").arg(name));
+            return;
+        }
+
+        sources.append(fi.absoluteFilePath());
+        targets.append(target);
+    }
+
+    if (sources.isEmpty()) {
+        emit operationFinished(true, tr("Nothing to rename"));
+        return;
+    }
+
+    for (const QString& target : std::as_const(targets)) {
+        if (QFileInfo::exists(target) && !sources.contains(target)) {
+            emit operationFinished(false, tr("Rename failed: %1 already exists").arg(QFileInfo(target).fileName()));
+            return;
+        }
+    }
+
+    QStringList staged;
+    staged.reserve(sources.size());
+
+    for (int i = 0; i < sources.size(); ++i) {
+        QString temp;
+        int suffix = 0;
+        do {
+            temp = QStringLiteral("%1.prism-rename-%2").arg(targets.at(i)).arg(suffix++);
+        } while (QFileInfo::exists(temp));
+
+        if (!QFile::rename(sources.at(i), temp)) {
+            for (int j = staged.size() - 1; j >= 0; --j)
+                QFile::rename(staged.at(j), sources.at(j));
+            emit operationFinished(false, tr("Rename failed: could not rename %1").arg(QFileInfo(sources.at(i)).fileName()));
+            return;
+        }
+        staged.append(temp);
+    }
+
+    for (int i = 0; i < staged.size(); ++i) {
+        if (!QFile::rename(staged.at(i), targets.at(i))) {
+            for (int j = i - 1; j >= 0; --j)
+                QFile::rename(targets.at(j), staged.at(j));
+            for (int j = staged.size() - 1; j >= 0; --j)
+                QFile::rename(staged.at(j), sources.at(j));
+            emit operationFinished(false, tr("Rename failed: could not rename %1").arg(QFileInfo(sources.at(i)).fileName()));
+            return;
+        }
+    }
+
+    UndoAction action;
+    action.type = UndoAction::BulkRename;
+    action.sourcePaths = sources;
+    action.destPaths = targets;
+    m_undoStack.push_back(action);
+    m_redoStack.clear();
+    emit undoStackChanged();
+
+    emit operationFinished(true, tr("Renamed %n item(s)", "", static_cast<int>(sources.size())));
+}
+
 void FileOperations::createDirectory(const QString& parentDir, const QString& name) {
     QDir dir(parentDir);
     bool success = dir.mkdir(name);
@@ -664,6 +752,14 @@ void FileOperations::undo() {
         m_redoStack.push_back(action);
         emit undoStackChanged();
         emit operationFinished(true, tr("Undid move"));
+    } else if (action.type == UndoAction::BulkRename) {
+        for (int i = action.destPaths.size() - 1; i >= 0; --i) {
+            if (i < action.sourcePaths.size())
+                QFile::rename(action.destPaths.at(i), action.sourcePaths.at(i));
+        }
+        m_redoStack.push_back(action);
+        emit undoStackChanged();
+        emit operationFinished(true, tr("Undid rename"));
     } else if (action.type == UndoAction::MoveToTrash) {
         for (const QString& info : action.trashInfoPaths) {
             restoreFromTrash(info);
@@ -685,6 +781,14 @@ void FileOperations::redo() {
             emit undoStackChanged();
             emit operationFinished(true, tr("Redid rename"));
         }
+    } else if (action.type == UndoAction::BulkRename) {
+        for (int i = 0; i < action.sourcePaths.size(); ++i) {
+            if (i < action.destPaths.size())
+                QFile::rename(action.sourcePaths.at(i), action.destPaths.at(i));
+        }
+        m_undoStack.push_back(action);
+        emit undoStackChanged();
+        emit operationFinished(true, tr("Redid rename"));
     } else if (action.type == UndoAction::CreateDirectory) {
         createDirectory(action.parentDir, action.name);
     } else if (action.type == UndoAction::CreateFile) {

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -123,6 +123,7 @@ public:
     Q_INVOKABLE void restoreFromTrash(const QString& trashInfoPath);
     Q_INVOKABLE void emptyTrash();
     Q_INVOKABLE void renameFile(const QString& oldPath, const QString& newName);
+    Q_INVOKABLE void bulkRename(const QStringList& paths, const QStringList& newNames);
     Q_INVOKABLE void createDirectory(const QString& parentDir, const QString& name);
     Q_INVOKABLE void createFile(const QString& parentDir, const QString& name, const QString& content = "");
     Q_INVOKABLE void duplicateFile(const QString& path);
@@ -150,7 +151,8 @@ private:
             CreateDirectory,
             Move,
             Copy,
-            MoveToTrash
+            MoveToTrash,
+            BulkRename
         } type;
         QString oldPath;
         QString newPath;

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -118,6 +118,25 @@ QString FileUtils::baseName(const QString& path) {
     return QFileInfo(path).fileName();
 }
 
+QVariantList FileUtils::describePaths(const QStringList& paths) {
+    QVariantList entries;
+    entries.reserve(paths.size());
+
+    for (const QString& path : paths) {
+        const QFileInfo fi(path);
+        if (!fi.exists())
+            continue;
+
+        QVariantMap entry;
+        entry.insert(QStringLiteral("path"), fi.absoluteFilePath());
+        entry.insert(QStringLiteral("name"), fi.fileName());
+        entry.insert(QStringLiteral("isDir"), fi.isDir());
+        entries.append(entry);
+    }
+
+    return entries;
+}
+
 bool FileUtils::isImage(const QString& path) {
     if (path.isEmpty()) return false;
     static const QMimeDatabase db;

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -49,6 +49,7 @@ public:
     Q_INVOKABLE static QString shortenHome(const QString& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
     Q_INVOKABLE static QString baseName(const QString& path);
+    Q_INVOKABLE static QVariantList describePaths(const QStringList& paths);
     Q_INVOKABLE static bool isImage(const QString& path);
     Q_INVOKABLE static bool isVideo(const QString& path);
     Q_INVOKABLE static bool isAudio(const QString& path);


### PR DESCRIPTION
## Problem

Rename is written for one file. Selecting several and choosing it opens the single item dialog against whichever file the menu was raised on; the rest have to be renamed one at a time.

## Change

Two or more selected items open a bulk dialog instead. One selected item is unchanged.

Two modes. **Find and replace** substitutes across all the names. **Numbered** takes a pattern where `#` becomes a counter, repeated to pad with zeros, and `{name}` inserts the existing name. The extension is preserved, and a directory has no extension to preserve.

Every row of the preview shows the old name against the new one. Unchanged names are muted, changed ones highlighted, and refused ones marked in the error colour with the reason: empty, contains a separator, or claimed by another row. The button is disabled while any row is refused, and while nothing would change.

## Two passes

Renaming a set that exchanges names among itself, `1.txt` and `2.txt` swapping, would destroy a file if applied in order. Everything is moved to temporary names first and to the final names second.

A failure in either pass rolls the whole batch back, so the result is either the full rename or the original state, never half of it. The names are all validated before anything moves, which keeps the rollback path to genuine filesystem failures.

## Undo

`UndoAction` already carried source and destination lists for moves, so the batch is one entry using the same shape. Fifty files take one undo rather than fifty. Redo replays it.

## Supporting change

`FileUtils::describePaths` returns name, path and directory flag for a list of paths. The dialog needs to know which entries are directories to leave their extensions alone, and deriving that in QML from a path alone is not possible.

## Verified

The preview transformation was tested separately against find and replace, zero padded and unpadded counters, `{name}` substitution, directories keeping their whole name, and a pattern that produces the same name twice being refused. Renaming on disk, including the swap case and undoing it, was tested by @eximora-private.
