### PR TITLE
fix: stop deleting the contents of a symlinked folder

### DIFF
--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -1,4 +1,5 @@
 #include "fileoperations.hpp"
+#include <unistd.h>
 
 #include "catboxuploader.hpp"
 #include <QDir>
@@ -100,6 +101,24 @@ qint64 FileOperations::calculateTotalSize(const QStringList& paths) {
     return total;
 }
 
+static bool entryExists(const QFileInfo& info) {
+    return info.exists() || info.isSymLink();
+}
+
+static QString rawSymLinkTarget(const QString& path) {
+    const QByteArray encoded = QFile::encodeName(path);
+    QByteArray buffer(1024, Qt::Uninitialized);
+
+    while (true) {
+        const ssize_t written = ::readlink(encoded.constData(), buffer.data(), buffer.size());
+        if (written < 0)
+            return {};
+        if (written < buffer.size())
+            return QFile::decodeName(buffer.left(written));
+        buffer.resize(buffer.size() * 2);
+    }
+}
+
 bool FileOperations::copyRecursively(const QString& src, const QString& dest, std::atomic<bool>& cancelFlag, qint64& processedBytes, qint64 totalBytes) {
     if (cancelFlag.load())
         return false;
@@ -110,6 +129,15 @@ bool FileOperations::copyRecursively(const QString& src, const QString& dest, st
     // Prevent copying a file or folder onto its exact self
     if (srcInfo.canonicalFilePath() == destInfo.canonicalFilePath() && !srcInfo.canonicalFilePath().isEmpty()) {
         return false;
+    }
+
+    if (srcInfo.isSymLink()) {
+        const QString target = rawSymLinkTarget(src);
+        if (target.isEmpty())
+            return false;
+        if (QFileInfo(dest).isSymLink() || QFileInfo::exists(dest))
+            QFile::remove(dest);
+        return QFile::link(target, dest);
     }
 
     if (srcInfo.isDir()) {
@@ -158,12 +186,13 @@ bool FileOperations::copyRecursively(const QString& src, const QString& dest, st
 
 bool FileOperations::removeRecursively(const QString& path) {
     QFileInfo fi(path);
+    if (fi.isSymLink())
+        return QFile::remove(path);
     if (fi.isDir()) {
         QDir dir(path);
         return dir.removeRecursively();
-    } else {
-        return QFile::remove(path);
     }
+    return QFile::remove(path);
 }
 
 void FileOperations::copyFiles(const QStringList& sources, const QString& destinationDir) {
@@ -251,7 +280,7 @@ void FileOperations::moveFiles(const QStringList& sources, const QString& destin
                     break;
                 }
                 QFileInfo srcFi(src);
-                if (!srcFi.exists()) {
+                if (!entryExists(srcFi)) {
                     continue;
                 }
 
@@ -440,7 +469,7 @@ void FileOperations::moveToTrash(const QStringList& paths) {
 
         for (const QString& p : paths) {
             QFileInfo fi(p);
-            if (!fi.exists())
+            if (!entryExists(fi))
                 continue;
 
             QString fileName = fi.fileName();


### PR DESCRIPTION
## Problem

Reported by @DiM as the trash having issues with symlinked folders. It is worse than that, and it is not confined to the trash.

`QFileInfo::isDir()` follows the link. For a symlink pointing at a directory it returns true, so `removeRecursively` took the directory branch and called `QDir::removeRecursively` on the link path. That walks through the link and **empties the target**, leaving the symlink itself in place.

Reproduced: a link `verweis` to a directory `echt` containing `wichtig.txt`. Removing `verweis` left the link present, the directory present, and `wichtig.txt` gone.

Three call sites reach it: permanent delete, the copy fallback in move, and the same fallback in move to trash. The last two run whenever a rename crosses a filesystem, which is exactly the case where the user is least expecting the slow path to also be destructive.

Two neighbours of the same cause:

`copyRecursively` also tested `isDir()` first, so copying a symlinked folder descended into the target and produced a real directory holding a copy of its contents rather than a link.

`QFileInfo::exists()` follows the link as well, so a symlink whose target is gone counted as absent. Move and trash skipped broken links silently, and there was no way to get rid of one.

## Change

Test `isSymLink()` before `isDir()` in both recursive helpers. Removing a link removes the link. Copying one recreates it at the destination.

Existence checks in move and trash now accept a symlink whether or not its target resolves.

The link target is read with `readlink` rather than `QFileInfo::symLinkTarget()`. Qt resolves a relative link to an absolute path, so copying a tree of relative links would leave every one of them pointing back at the original location, which breaks the copy the moment either tree moves.

`emptyTrash` already guarded its own recursion with `!entry.isSymLink()` and is unchanged.

## Verified

Thirteen checks against a synthetic tree covering: removing a symlinked directory leaving both the target and its contents intact; copying one producing a link rather than a directory; a relative target surviving the copy unchanged; and a broken link counting as present, being removable, while plain `exists()` still reports false for it.

Confirmed in the running application by @eximora-private against a directory holding a valid link, a broken link and a real target, through both trash and permanent delete.
