### PR TITLE
Feat: Scroll speed controller

### DIFF
--- a/qml/components/controls/StyledSlider.qml
+++ b/qml/components/controls/StyledSlider.qml
@@ -7,6 +7,10 @@ T.Slider {
     id: root
 
     property int radius: Tokens.rounding.full
+    property int trackHeight: 6
+    property int handleWidth: 3
+    property int handleHeight: 14
+    property int handleHeightPressed: 18
     property bool interactionOnMove: true
     readonly property bool dragging: mouse.pressed
 
@@ -35,7 +39,7 @@ T.Slider {
             anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: Tokens.spacing.extraSmall
 
-            implicitHeight: 6
+            implicitHeight: root.trackHeight
             opacity: Math.min(width, 10) / 10
 
             radius: root.radius
@@ -62,8 +66,8 @@ T.Slider {
             anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: 2
 
-            implicitWidth: 3
-            implicitHeight: mouse.pressed ? 18 : 14
+            implicitWidth: root.handleWidth
+            implicitHeight: mouse.pressed ? root.handleHeightPressed : root.handleHeight
 
             radius: Tokens.rounding.full
             color: root.fgColour
@@ -82,7 +86,7 @@ T.Slider {
             anchors.verticalCenter: parent.verticalCenter
 
             implicitWidth: root.filledWidth
-            implicitHeight: 6
+            implicitHeight: root.trackHeight
 
             radius: root.radius
             color: root.fgColour
@@ -101,7 +105,7 @@ T.Slider {
         anchors.verticalCenter: parent.verticalCenter
 
         preventStealing: true
-        implicitHeight: 18
+        implicitHeight: Math.max(18, root.handleHeightPressed)
 
         onPressed: e => {
             widthBehavior.enabled = false;

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -421,72 +421,72 @@ MouseArea {
                                 first: true
                                 last: true
                                 Layout.fillWidth: true
-                                implicitHeight: scrollRow.implicitHeight + Tokens.padding.largeIncreased + Tokens.padding.large
+                                implicitHeight: scrollColumn.implicitHeight + Tokens.padding.largeIncreased + Tokens.padding.large
 
-                                RowLayout {
-                                    id: scrollRow
+                                ColumnLayout {
+                                    id: scrollColumn
 
                                     anchors.fill: parent
                                     anchors.margins: Tokens.padding.largeIncreased
                                     anchors.topMargin: Tokens.padding.large
                                     spacing: Tokens.spacing.medium
 
-                                    MaterialIcon {
-                                        text: "speed"
-                                        color: Colours.palette.m3onSurfaceVariant
-                                        fontStyle: Tokens.font.icon.medium
-                                    }
-
-                                    ColumnLayout {
+                                    RowLayout {
                                         Layout.fillWidth: true
-                                        spacing: Tokens.spacing.medium
+                                        spacing: Tokens.spacing.small
 
-                                        RowLayout {
-                                            Layout.fillWidth: true
-                                            spacing: Tokens.spacing.small
+                                        MaterialIcon {
+                                            text: "speed"
+                                            color: Colours.palette.m3onSurfaceVariant
+                                            fontStyle: Tokens.font.icon.medium
+                                        }
 
-                                            StyledText {
-                                                text: qsTr("Scroll Speed")
-                                                color: Colours.palette.m3onSurface
-                                                font: Tokens.font.body.small
-                                                elide: Text.ElideRight
-                                            }
+                                        StyledText {
+                                            Layout.leftMargin: Tokens.spacing.extraSmall
+                                            text: qsTr("Scroll Speed")
+                                            color: Colours.palette.m3onSurface
+                                            font: Tokens.font.body.small
+                                            elide: Text.ElideRight
+                                        }
 
-                                            IconButton {
-                                                type: ButtonBase.Text
-                                                icon: "restart_alt"
-                                                fontStyle: Tokens.font.icon.small
-                                                opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1 : 0
-                                                enabled: opacity > 0.01
-                                                onClicked: AppController.resetScrollSpeed()
+                                        IconButton {
+                                            type: ButtonBase.Text
+                                            icon: "restart_alt"
+                                            fontStyle: Tokens.font.icon.small
+                                            opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1 : 0
+                                            enabled: opacity > 0.01
+                                            onClicked: AppController.resetScrollSpeed()
 
-                                                Behavior on opacity {
-                                                    Anim { type: Anim.FastEffects }
-                                                }
-                                            }
-
-                                            Item {
-                                                Layout.fillWidth: true
-                                            }
-
-                                            StyledText {
-                                                text: qsTr("%1x").arg(AppController.scrollSpeed.toFixed(1))
-                                                color: Colours.palette.m3outline
-                                                font: Tokens.font.body.small
+                                            Behavior on opacity {
+                                                Anim { type: Anim.FastEffects }
                                             }
                                         }
 
-                                        StyledSlider {
+                                        Item {
                                             Layout.fillWidth: true
-                                            implicitHeight: Tokens.padding.medium * 2
+                                        }
 
-                                            radius: Tokens.rounding.small
-                                            from: 0.5
-                                            to: 2.5
-                                            value: AppController.scrollSpeed
-                                            onInteraction: v => {
-                                                AppController.scrollSpeed = Math.round(v * 10) / 10;
-                                            }
+                                        StyledText {
+                                            text: qsTr("%1x").arg(AppController.scrollSpeed.toFixed(1))
+                                            color: Colours.palette.m3outline
+                                            font: Tokens.font.body.small
+                                        }
+                                    }
+
+                                    StyledSlider {
+                                        Layout.fillWidth: true
+                                        implicitHeight: Tokens.padding.medium * 2
+
+                                        radius: Tokens.rounding.small
+                                        trackHeight: 10
+                                        handleWidth: 4
+                                        handleHeight: 26
+                                        handleHeightPressed: 32
+                                        from: 0.5
+                                        to: 2.5
+                                        value: AppController.scrollSpeed
+                                        onInteraction: v => {
+                                            AppController.scrollSpeed = Math.round(v * 10) / 10;
                                         }
                                     }
                                 }

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -357,19 +357,17 @@ MouseArea {
                                 first: true
                                 last: true
                                 Layout.fillWidth: true
-                                implicitHeight: Math.max(52, scrollRow.implicitHeight + Tokens.padding.medium * 2)
+                                implicitHeight: scrollRow.implicitHeight + Tokens.padding.largeIncreased + Tokens.padding.large
 
                                 RowLayout {
                                     id: scrollRow
-                                    anchors.left: parent.left
-                                    anchors.right: parent.right
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    anchors.leftMargin: Tokens.padding.large
-                                    anchors.rightMargin: Tokens.padding.large
+
+                                    anchors.fill: parent
+                                    anchors.margins: Tokens.padding.largeIncreased
+                                    anchors.topMargin: Tokens.padding.large
                                     spacing: Tokens.spacing.medium
 
                                     MaterialIcon {
-                                        Layout.alignment: Qt.AlignVCenter
                                         text: "speed"
                                         color: Colours.palette.m3onSurfaceVariant
                                         fontStyle: Tokens.font.icon.medium
@@ -377,51 +375,54 @@ MouseArea {
 
                                     ColumnLayout {
                                         Layout.fillWidth: true
-                                        Layout.alignment: Qt.AlignVCenter
-                                        spacing: 2
+                                        spacing: Tokens.spacing.medium
 
-                                        StyledText {
+                                        RowLayout {
                                             Layout.fillWidth: true
-                                            text: qsTr("Scroll Speed")
-                                            font: Tokens.font.body.small
-                                            color: Colours.palette.m3onSurface
-                                            elide: Text.ElideRight
+                                            spacing: Tokens.spacing.small
+
+                                            StyledText {
+                                                text: qsTr("Scroll Speed")
+                                                color: Colours.palette.m3onSurface
+                                                font: Tokens.font.body.small
+                                                elide: Text.ElideRight
+                                            }
+
+                                            IconButton {
+                                                type: ButtonBase.Text
+                                                icon: "restart_alt"
+                                                fontStyle: Tokens.font.icon.small
+                                                opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1 : 0
+                                                enabled: opacity > 0.01
+                                                onClicked: AppController.resetScrollSpeed()
+
+                                                Behavior on opacity {
+                                                    Anim { type: Anim.FastEffects }
+                                                }
+                                            }
+
+                                            Item {
+                                                Layout.fillWidth: true
+                                            }
+
+                                            StyledText {
+                                                text: qsTr("%1x").arg(AppController.scrollSpeed.toFixed(1))
+                                                color: Colours.palette.m3outline
+                                                font: Tokens.font.body.small
+                                            }
                                         }
 
-                                        StyledText {
+                                        StyledSlider {
                                             Layout.fillWidth: true
-                                            text: qsTr("Sensitivity: %1x%2")
-                                                .arg(AppController.scrollSpeed.toFixed(1))
-                                                .arg(Math.abs(AppController.scrollSpeed - 1.0) < 0.05 ? qsTr(" (Default)") : "")
-                                            color: Colours.palette.m3outline
-                                            font: Tokens.font.label.small
-                                            elide: Text.ElideRight
-                                        }
-                                    }
+                                            implicitHeight: Tokens.padding.medium * 2
 
-                                    StyledSlider {
-                                        id: scrollSlider
-                                        Layout.alignment: Qt.AlignVCenter
-                                        implicitWidth: 120
-                                        implicitHeight: 8
-                                        from: 0.5
-                                        to: 2.5
-                                        value: AppController.scrollSpeed
-                                        onInteraction: v => {
-                                            AppController.scrollSpeed = Math.round(v * 10) / 10;
-                                        }
-                                    }
-
-                                    IconButton {
-                                        Layout.alignment: Qt.AlignVCenter
-                                        type: ButtonBase.Text
-                                        icon: "restart_alt"
-                                        opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1.0 : 0.0
-                                        enabled: opacity > 0.01
-                                        onClicked: AppController.resetScrollSpeed()
-
-                                        Behavior on opacity {
-                                            Anim { type: Anim.FastEffects }
+                                            radius: Tokens.rounding.small
+                                            from: 0.5
+                                            to: 2.5
+                                            value: AppController.scrollSpeed
+                                            onInteraction: v => {
+                                                AppController.scrollSpeed = Math.round(v * 10) / 10;
+                                            }
                                         }
                                     }
                                 }

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -348,6 +348,83 @@ MouseArea {
                             Item { implicitHeight: 4 }
 
                             StyledText {
+                                text: qsTr("Scroll Sensitivity")
+                                color: Colours.palette.m3primary
+                                font: Tokens.font.label.large
+                            }
+
+                            ConnectedRect {
+                                first: true
+                                last: true
+                                Layout.fillWidth: true
+                                implicitHeight: scrollRow.implicitHeight + scrollRow.anchors.margins * 2
+
+                                RowLayout {
+                                    id: scrollRow
+                                    anchors.fill: parent
+                                    anchors.margins: Tokens.padding.medium
+                                    anchors.leftMargin: Tokens.padding.largeIncreased
+                                    anchors.rightMargin: Tokens.padding.largeIncreased
+                                    spacing: Tokens.spacing.medium
+
+                                    MaterialIcon {
+                                        text: "speed"
+                                        color: Colours.palette.m3onSurfaceVariant
+                                        fontStyle: Tokens.font.icon.medium
+                                    }
+
+                                    ColumnLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 2
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Scroll Speed")
+                                            font: Tokens.font.body.small
+                                            color: Colours.palette.m3onSurface
+                                            elide: Text.ElideRight
+                                        }
+
+                                        StyledText {
+                                            Layout.fillWidth: true
+                                            text: qsTr("Sensitivity: %1x%2")
+                                                .arg(AppController.scrollSpeed.toFixed(1))
+                                                .arg(Math.abs(AppController.scrollSpeed - 1.0) < 0.05 ? qsTr(" (Default)") : "")
+                                            color: Colours.palette.m3outline
+                                            font: Tokens.font.label.small
+                                            elide: Text.ElideRight
+                                        }
+                                    }
+
+                                    StyledSlider {
+                                        id: scrollSlider
+                                        implicitWidth: 120
+                                        implicitHeight: 8
+                                        from: 0.5
+                                        to: 2.5
+                                        value: AppController.scrollSpeed
+                                        onInteraction: v => {
+                                            AppController.scrollSpeed = Math.round(v * 10) / 10;
+                                        }
+                                    }
+
+                                    IconButton {
+                                        type: ButtonBase.Text
+                                        icon: "restart_alt"
+                                        opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1.0 : 0.0
+                                        enabled: opacity > 0.01
+                                        onClicked: AppController.resetScrollSpeed()
+
+                                        Behavior on opacity {
+                                            Anim { type: Anim.FastEffects }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Item { implicitHeight: 4 }
+
+                            StyledText {
                                 text: qsTr("Thumbnail Generation")
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -357,17 +357,19 @@ MouseArea {
                                 first: true
                                 last: true
                                 Layout.fillWidth: true
-                                implicitHeight: scrollRow.implicitHeight + scrollRow.anchors.margins * 2
+                                implicitHeight: Math.max(52, scrollRow.implicitHeight + Tokens.padding.medium * 2)
 
                                 RowLayout {
                                     id: scrollRow
-                                    anchors.fill: parent
-                                    anchors.margins: Tokens.padding.medium
-                                    anchors.leftMargin: Tokens.padding.largeIncreased
-                                    anchors.rightMargin: Tokens.padding.largeIncreased
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    anchors.leftMargin: Tokens.padding.large
+                                    anchors.rightMargin: Tokens.padding.large
                                     spacing: Tokens.spacing.medium
 
                                     MaterialIcon {
+                                        Layout.alignment: Qt.AlignVCenter
                                         text: "speed"
                                         color: Colours.palette.m3onSurfaceVariant
                                         fontStyle: Tokens.font.icon.medium
@@ -375,6 +377,7 @@ MouseArea {
 
                                     ColumnLayout {
                                         Layout.fillWidth: true
+                                        Layout.alignment: Qt.AlignVCenter
                                         spacing: 2
 
                                         StyledText {
@@ -398,6 +401,7 @@ MouseArea {
 
                                     StyledSlider {
                                         id: scrollSlider
+                                        Layout.alignment: Qt.AlignVCenter
                                         implicitWidth: 120
                                         implicitHeight: 8
                                         from: 0.5
@@ -409,6 +413,7 @@ MouseArea {
                                     }
 
                                     IconButton {
+                                        Layout.alignment: Qt.AlignVCenter
                                         type: ButtonBase.Text
                                         icon: "restart_alt"
                                         opacity: Math.abs(AppController.scrollSpeed - 1.0) >= 0.05 ? 1.0 : 0.0

--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -176,14 +176,15 @@ Item {
             acceptedModifiers: Qt.NoModifier
             onWheel: event => {
                 let vx = 0;
+                let factor = AppController.scrollSpeed;
                 if (event.pixelDelta.x !== 0) {
-                    vx = event.pixelDelta.x * 25;
+                    vx = event.pixelDelta.x * 25 * factor;
                 } else if (event.pixelDelta.y !== 0) {
-                    vx = event.pixelDelta.y * 25;
+                    vx = event.pixelDelta.y * 25 * factor;
                 } else if (event.angleDelta.y !== 0) {
-                    vx = event.angleDelta.y * 14;
+                    vx = event.angleDelta.y * 14 * factor;
                 } else if (event.angleDelta.x !== 0) {
-                    vx = event.angleDelta.x * 14;
+                    vx = event.angleDelta.x * 14 * factor;
                 }
                 if (vx !== 0) {
                     gridView.flick(vx, 0);
@@ -589,14 +590,15 @@ Item {
                 wheel.accepted = true;
             } else {
                 let vx = 0;
+                let factor = AppController.scrollSpeed;
                 if (wheel.pixelDelta.x !== 0) {
-                    vx = wheel.pixelDelta.x * 25;
+                    vx = wheel.pixelDelta.x * 25 * factor;
                 } else if (wheel.pixelDelta.y !== 0) {
-                    vx = wheel.pixelDelta.y * 25;
+                    vx = wheel.pixelDelta.y * 25 * factor;
                 } else if (wheel.angleDelta.y !== 0) {
-                    vx = wheel.angleDelta.y * 14;
+                    vx = wheel.angleDelta.y * 14 * factor;
                 } else if (wheel.angleDelta.x !== 0) {
-                    vx = wheel.angleDelta.x * 14;
+                    vx = wheel.angleDelta.x * 14 * factor;
                 }
                 if (vx !== 0) {
                     gridView.flick(vx, 0);

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -475,10 +475,11 @@ Item {
                 acceptedModifiers: Qt.NoModifier
                 onWheel: event => {
                     let vy = 0;
+                    let factor = AppController.scrollSpeed;
                     if (event.pixelDelta.y !== 0) {
-                        vy = event.pixelDelta.y * 25;
+                        vy = event.pixelDelta.y * 25 * factor;
                     } else if (event.angleDelta.y !== 0) {
-                        vy = event.angleDelta.y * 14;
+                        vy = event.angleDelta.y * 14 * factor;
                     }
                     if (vy !== 0) {
                         listView.flick(0, vy);
@@ -895,10 +896,11 @@ Item {
                 wheel.accepted = true;
             } else {
                 let vy = 0;
+                let factor = AppController.scrollSpeed;
                 if (wheel.pixelDelta.y !== 0) {
-                    vy = wheel.pixelDelta.y * 25;
+                    vy = wheel.pixelDelta.y * 25 * factor;
                 } else if (wheel.angleDelta.y !== 0) {
-                    vy = wheel.angleDelta.y * 14;
+                    vy = wheel.angleDelta.y * 14 * factor;
                 }
                 if (vy !== 0) {
                     listView.flick(0, vy);

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -185,10 +185,11 @@ Item {
             acceptedModifiers: Qt.NoModifier
             onWheel: event => {
                 let vy = 0;
+                let factor = AppController.scrollSpeed;
                 if (event.pixelDelta.y !== 0) {
-                    vy = event.pixelDelta.y * 25;
+                    vy = event.pixelDelta.y * 25 * factor;
                 } else if (event.angleDelta.y !== 0) {
-                    vy = event.angleDelta.y * 14;
+                    vy = event.angleDelta.y * 14 * factor;
                 }
                 if (vy !== 0) {
                     view.flick(0, vy);
@@ -636,10 +637,11 @@ Item {
                 wheel.accepted = true;
             } else {
                 let vy = 0;
+                let factor = AppController.scrollSpeed;
                 if (wheel.pixelDelta.y !== 0) {
-                    vy = wheel.pixelDelta.y * 25;
+                    vy = wheel.pixelDelta.y * 25 * factor;
                 } else if (wheel.angleDelta.y !== 0) {
-                    vy = wheel.angleDelta.y * 14;
+                    vy = wheel.angleDelta.y * 14 * factor;
                 }
                 if (vy !== 0) {
                     view.flick(0, vy);

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -63,6 +63,10 @@ AppController::AppController(QObject* parent)
     m_menuShowTerminal = settings.value("contextMenu/showTerminal", true).toBool();
     m_menuShowDelete = settings.value("contextMenu/showDelete", true).toBool();
     m_showNetworkSection = settings.value("preferences/showNetworkSection", false).toBool();
+    m_scrollSpeed = settings.value("preferences/scrollSpeed", 1.0).toReal();
+    if (m_scrollSpeed <= 0.05) {
+        m_scrollSpeed = 1.0;
+    }
 
     const QByteArray widthsJson = settings.value("preferences/detailsColumnWidths").toString().toUtf8();
     if (!widthsJson.isEmpty()) {
@@ -392,6 +396,19 @@ void AppController::setShowNetworkSection(bool show) {
         settings.setValue("preferences/showNetworkSection", show);
         emit showNetworkSectionChanged();
     }
+}
+
+void AppController::setScrollSpeed(qreal speed) {
+    if (!qFuzzyCompare(m_scrollSpeed + 1.0, speed + 1.0)) {
+        m_scrollSpeed = speed;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/scrollSpeed", speed);
+        emit scrollSpeedChanged();
+    }
+}
+
+void AppController::resetScrollSpeed() {
+    setScrollSpeed(1.0);
 }
 
 void AppController::triggerIconReload() {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -46,6 +46,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool menuShowTerminal READ menuShowTerminal WRITE setMenuShowTerminal NOTIFY menuPreferencesChanged)
     Q_PROPERTY(bool menuShowDelete READ menuShowDelete WRITE setMenuShowDelete NOTIFY menuPreferencesChanged)
     Q_PROPERTY(bool showNetworkSection READ showNetworkSection WRITE setShowNetworkSection NOTIFY showNetworkSectionChanged)
+    Q_PROPERTY(qreal scrollSpeed READ scrollSpeed WRITE setScrollSpeed NOTIFY scrollSpeedChanged)
 
 public:
     explicit AppController(QObject* parent = nullptr);
@@ -145,6 +146,10 @@ public:
     [[nodiscard]] bool showNetworkSection() const { return m_showNetworkSection; }
     void setShowNetworkSection(bool show);
 
+    [[nodiscard]] qreal scrollSpeed() const { return m_scrollSpeed; }
+    void setScrollSpeed(qreal speed);
+    Q_INVOKABLE void resetScrollSpeed();
+
     Q_INVOKABLE void accept(const QString& path);
     Q_INVOKABLE void reject();
 
@@ -176,6 +181,7 @@ signals:
     void iconThemeVersionChanged();
     void menuPreferencesChanged();
     void showNetworkSectionChanged();
+    void scrollSpeedChanged();
     void accepted(const QString& path);
     void rejected();
 
@@ -213,6 +219,7 @@ private:
     bool m_menuShowTerminal = true;
     bool m_menuShowDelete = true;
     bool m_showNetworkSection = false;
+    qreal m_scrollSpeed = 1.0;
 };
 
 } // namespace prism::core


### PR DESCRIPTION
Adds a configurable scroll speed slider under **Preferences General** allowing users to adjust mouse wheel and trackpad scroll sensitivity.

### Changes
- **Backend (`AppController`)**: Added `scrollSpeed` property (`qreal`, default `1.0`) with `QSettings` persistence under `preferences/scrollSpeed`.
- **UI (`PreferencesModal.qml`)**: Added a `Scroll Sensitivity` settings row using `StyledSlider`, with a multiplier indicator and reset button.
- **Views**: Scaled flick velocity for touchpad and wheel events in `FileGridView`, `FileDetailsView`, and `FileCompactView`.

<img width="581" height="560" alt="image" src="https://github.com/user-attachments/assets/cd635512-b61b-46fb-bfbc-3f9398790833" />

