### PR TITLE
fix: keep the upload task visible in the operations modal

### DIFF
--- a/src/core/catboxuploader.cpp
+++ b/src/core/catboxuploader.cpp
@@ -264,7 +264,9 @@ void CatboxUploader::onUploadProgress(qint64 bytesSent, qint64 bytesTotal) {
             foProgress->setProgress(m_uploadProgress);
             const QString queued = m_uploadQueue.isEmpty()
                 ? QString()
-                : tr(", %n more queued", "", static_cast<int>(m_uploadQueue.size()));
+                : (m_uploadQueue.size() == 1
+                       ? tr(", 1 more queued")
+                       : tr(", %1 more queued").arg(m_uploadQueue.size()));
             foProgress->setStatusText(m_uploadProgress >= 1.0
                     ? tr("Waiting for %1 to process %2...").arg(m_currentService, m_currentFileName) + queued
                     : tr("Uploading %1 to %2 (%3%)")

--- a/src/core/catboxuploader.cpp
+++ b/src/core/catboxuploader.cpp
@@ -39,6 +39,16 @@ QString CatboxUploader::serviceDisplayName(Service service, const QString& time)
         : QStringLiteral("Litterbox (%1)").arg(time.isEmpty() ? QStringLiteral("24h") : time);
 }
 
+void CatboxUploader::beginSharedProgress(const QString& statusText) {
+    m_ownsSharedProgress = true;
+
+    auto* foProgress = FileOperations::instance()->progress();
+    if (foProgress) {
+        foProgress->setRunning(true);
+        foProgress->setStatusText(statusText);
+    }
+}
+
 void CatboxUploader::clearSharedProgress(const QString& finalStatusText) {
     if (!m_ownsSharedProgress)
         return;
@@ -82,6 +92,11 @@ void CatboxUploader::enqueue(const QStringList& filePaths, Service service, cons
         return;
     }
 
+    if (m_isUploading && !m_currentReply)
+        m_isUploading = false;
+
+    beginSharedProgress(tr("Preparing to upload to %1...").arg(serviceName));
+
     if (!m_isUploading)
         processNextInQueue();
 }
@@ -102,10 +117,11 @@ void CatboxUploader::uploadFilesToLitterbox(const QStringList& filePaths, const 
 void CatboxUploader::cancelUpload() {
     m_uploadQueue.clear();
 
-    if (m_currentReply) {
-        m_currentReply->abort();
-        m_currentReply->deleteLater();
+    if (QNetworkReply* reply = m_currentReply) {
         m_currentReply = nullptr;
+        reply->disconnect(this);
+        reply->abort();
+        reply->deleteLater();
     }
 
     if (m_isUploading) {
@@ -246,19 +262,22 @@ void CatboxUploader::onUploadProgress(qint64 bytesSent, qint64 bytesTotal) {
         auto* foProgress = FileOperations::instance()->progress();
         if (foProgress && foProgress->running()) {
             foProgress->setProgress(m_uploadProgress);
+            const QString queued = m_uploadQueue.isEmpty()
+                ? QString()
+                : tr(", %n more queued", "", static_cast<int>(m_uploadQueue.size()));
             foProgress->setStatusText(m_uploadProgress >= 1.0
-                    ? tr("Waiting for %1 to process %2...").arg(m_currentService, m_currentFileName)
+                    ? tr("Waiting for %1 to process %2...").arg(m_currentService, m_currentFileName) + queued
                     : tr("Uploading %1 to %2 (%3%)")
                           .arg(m_currentFileName, m_currentService)
-                          .arg(static_cast<int>(m_uploadProgress * 100)));
+                          .arg(static_cast<int>(m_uploadProgress * 100)) + queued);
         }
     }
 }
 
 void CatboxUploader::onReplyFinished() {
-    if (!m_currentReply) return;
-
-    QNetworkReply* reply = m_currentReply;
+    QNetworkReply* reply = m_currentReply ? m_currentReply : qobject_cast<QNetworkReply*>(sender());
+    if (!reply)
+        return;
     m_currentReply = nullptr;
 
     QString currentFilePath = m_currentItem.filePath;

--- a/src/core/catboxuploader.hpp
+++ b/src/core/catboxuploader.hpp
@@ -73,6 +73,7 @@ private slots:
 
 private:
     void enqueue(const QStringList& filePaths, Service service, const QString& time);
+    void beginSharedProgress(const QString& statusText);
     void clearSharedProgress(const QString& finalStatusText = QString());
     static QString serviceDisplayName(Service service, const QString& time);
 

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -879,13 +879,13 @@ void FileOperations::addCompletedTask(bool success, const QString& message, cons
     task[QStringLiteral("url")] = url;
     task[QStringLiteral("time")] = QTime::currentTime().toString(QStringLiteral("hh:mm:ss"));
 
-    if (!m_completedTasks.isEmpty()) {
-        const auto first = m_completedTasks.first().toMap();
-        if (first.value(QStringLiteral("message")).toString() == message &&
-            first.value(QStringLiteral("url")).toString() == url) {
-            return;
-        }
+    const QString key = message + QLatin1Char('\n') + url;
+    if (key == m_lastCompletedTaskKey && m_lastCompletedTaskTimer.isValid()
+        && m_lastCompletedTaskTimer.elapsed() < 1000) {
+        return;
     }
+    m_lastCompletedTaskKey = key;
+    m_lastCompletedTaskTimer.restart();
 
     m_completedTasks.prepend(task);
     if (m_completedTasks.size() > 30) {

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QElapsedTimer>
 #include <QStringList>
 #include <QFutureWatcher>
 #include <atomic>
@@ -171,6 +172,8 @@ private:
     QStringList m_clipboardFiles;
     QStringList m_activeDragFiles;
     QVariantList m_completedTasks;
+    QString m_lastCompletedTaskKey;
+    QElapsedTimer m_lastCompletedTaskTimer;
     QList<UndoAction> m_undoStack;
     QList<UndoAction> m_redoStack;
     bool m_isCut = false;


### PR DESCRIPTION
## Problem

Reported by @DiM: the previous upload change made things worse and the task is gone from the modal entirely.

I could not reproduce a valid upload showing nothing. Driving `CatboxUploader` and `FileOperations` directly against a local HTTP server standing in for the API, the card appears on the click and clears on completion. So rather than guess at one cause, here is everything in that path that can end with nothing on screen.

**The claim moved later than the click.** The change put the progress claim in `processNextInQueue` instead of in `uploadToCatbox`. Between the click and that point sits the whole synchronous `readAll` of the file, so on anything large the modal stays empty while the application is busy. Worse, if `m_isUploading` is stale from an earlier upload, `enqueue` only queues and nothing is ever claimed.

**Completed tasks were being dropped.** `addCompletedTask` returns early when the message and url match the newest entry, with no time bound. A successful upload of the same file produces the same message and the same url, so uploading it twice records nothing the second time. Testing a fix by repeating the same upload is exactly how you hit this, and it presents as the task vanishing.

**Cancelling could dereference a cleared pointer.** `cancelUpload` called `abort()` on the member and then `deleteLater()` on it. `abort()` emits `finished`, `onReplyFinished` clears the member, and the next line went through it.

**A reply could strand the queue.** `onReplyFinished` returned early when the member was already null, without advancing the queue, leaving `m_isUploading` true so every later upload silently queued behind it.

## Change

The progress is claimed as soon as at least one path is accepted, so the card is up from the click; `processNextInQueue` then replaces the text with the per file one. An uploading flag with no reply behind it is treated as stale and reset rather than trusted.

The completed task check now only suppresses a repeat within a second, which is the duplicate burst it was meant to catch.

`cancelUpload` takes the reply into a local, clears the member and disconnects before aborting. `onReplyFinished` falls back to `sender()` so a late reply still advances the queue.

The status line also names how many files are queued behind the current one.

## Verified

Against a local server standing in for the API, checking `progress.running`, `isUploading` and the completed task count at each step: a valid upload; a directory being rejected; cancelling mid upload; uploading again after a cancel, which the stale flag used to block; and the same file three times in a row, which now records three entries where it previously recorded one.

@DiM, if what you saw was none of these, tell me the file and which service and I will chase that specific case. Reverting the original change is also fine by me, but it brings back the card that cannot be dismissed, so I would rather fix this properly.
