### PR TITLE
fix: stop QML and C++ using different singleton instances

### DIFF
--- a/src/config/tokens.hpp
+++ b/src/config/tokens.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include "font.hpp"
 #include <QObject>
 #include <QEasingCurve>
@@ -265,7 +268,6 @@ class TokensSingleton : public QObject {
     Q_PROPERTY(prism::config::SizeTokens* sizes READ sizes CONSTANT)
 
 public:
-    explicit TokensSingleton(QObject* parent = nullptr);
 
     RoundingTokens* rounding() const { return m_rounding; }
     SpacingTokens* spacing() const { return m_spacing; }
@@ -279,8 +281,12 @@ public:
     void reload();
 
     static TokensSingleton* instance();
+    static TokensSingleton* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
 private:
+    explicit TokensSingleton(QObject* parent = nullptr);
     RoundingTokens* m_rounding = nullptr;
     SpacingTokens* m_spacing = nullptr;
     PaddingTokens* m_padding = nullptr;

--- a/src/controllers/tabmanager.hpp
+++ b/src/controllers/tabmanager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QAbstractListModel>
 #include <QObject>
 #include <QString>
@@ -92,9 +95,11 @@ public:
     };
     Q_ENUM(TabRoles)
 
-    explicit TabManager(QObject* parent = nullptr);
 
     static TabManager* instance();
+    static TabManager* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -120,6 +125,7 @@ signals:
     void countChanged();
 
 private:
+    explicit TabManager(QObject* parent = nullptr);
     QVector<TabItem*> m_tabs;
     int m_currentIndex = 0;
 };

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QVariantMap>
 #include <QString>
@@ -48,9 +51,11 @@ class AppController : public QObject {
     Q_PROPERTY(bool showNetworkSection READ showNetworkSection WRITE setShowNetworkSection NOTIFY showNetworkSectionChanged)
 
 public:
-    explicit AppController(QObject* parent = nullptr);
 
     static AppController* instance();
+    static AppController* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] int iconThemeVersion() const { return m_iconThemeVersion; }
     Q_INVOKABLE void triggerIconReload();
@@ -180,6 +185,7 @@ signals:
     void rejected();
 
 private:
+    explicit AppController(QObject* parent = nullptr);
     QString m_title = "Select a file";
     QString m_initialDirectory;
     QString m_filterLabel = "All files";

--- a/src/core/appintegration.hpp
+++ b/src/core/appintegration.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QVariantList>
@@ -14,9 +17,11 @@ class AppIntegration : public QObject {
     QML_SINGLETON
 
 public:
-    explicit AppIntegration(QObject* parent = nullptr);
 
     static AppIntegration* instance();
+    static AppIntegration* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     Q_INVOKABLE QVariantList getAppsForFile(const QString& filePath);
     Q_INVOKABLE QVariantList getAvailableSharingServices();
@@ -42,6 +47,7 @@ public:
 
 
 private:
+    explicit AppIntegration(QObject* parent = nullptr);
     void scanDesktopFiles();
     void scanCustomActions();
 

--- a/src/core/catboxuploader.hpp
+++ b/src/core/catboxuploader.hpp
@@ -37,7 +37,6 @@ public:
         QString time = QStringLiteral("24h");
     };
 
-    explicit CatboxUploader(QObject* parent = nullptr);
     ~CatboxUploader() override;
 
     static CatboxUploader* instance();
@@ -72,6 +71,7 @@ private slots:
     void onReplyFinished();
 
 private:
+    explicit CatboxUploader(QObject* parent = nullptr);
     void enqueue(const QStringList& filePaths, Service service, const QString& time);
     void clearSharedProgress(const QString& finalStatusText = QString());
     static QString serviceDisplayName(Service service, const QString& time);

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -61,7 +61,6 @@ class FileOperations : public QObject {
     Q_PROPERTY(QVariantList completedTasks READ completedTasks NOTIFY completedTasksChanged)
 
 public:
-    explicit FileOperations(QObject* parent = nullptr);
 
     static FileOperations* instance();
     static FileOperations* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
@@ -143,6 +142,8 @@ signals:
     void conflictOccurred(const QString& source, const QString& destination);
 
 private:
+    explicit FileOperations(QObject* parent = nullptr);
+
     struct UndoAction {
         enum Type {
             Rename,

--- a/src/core/gitmanager.hpp
+++ b/src/core/gitmanager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -22,8 +25,10 @@ class GitManager : public QObject {
     Q_PROPERTY(QString lastStatusMessage READ lastStatusMessage NOTIFY statusMessageChanged)
 
 public:
-    explicit GitManager(QObject* parent = nullptr);
     static GitManager* instance();
+    static GitManager* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     QString currentPath() const { return m_currentPath; }
     void setCurrentPath(const QString& path);
@@ -47,6 +52,7 @@ signals:
     void statusMessageChanged();
 
 private:
+    explicit GitManager(QObject* parent = nullptr);
     QString findGitRoot(const QString& startPath) const;
 
     QString m_currentPath;

--- a/src/core/iconcatalog.hpp
+++ b/src/core/iconcatalog.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -15,8 +18,10 @@ class IconCatalog : public QObject {
     Q_PROPERTY(int totalIcons READ totalIcons CONSTANT)
 
 public:
-    explicit IconCatalog(QObject* parent = nullptr);
     static IconCatalog* instance();
+    static IconCatalog* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     int totalIcons() const { return m_icons.size(); }
 
@@ -24,6 +29,7 @@ public:
     Q_INVOKABLE QStringList getAllIcons() const { return m_icons; }
 
 private:
+    explicit IconCatalog(QObject* parent = nullptr);
     void loadIcons();
     QStringList m_icons;
 };

--- a/src/core/mimeservice.hpp
+++ b/src/core/mimeservice.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QVariantList>
@@ -14,8 +17,10 @@ class MimeService : public QObject {
     QML_SINGLETON
 
 public:
-    explicit MimeService(QObject* parent = nullptr);
     static MimeService* instance();
+    static MimeService* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     Q_INVOKABLE QVariantList getApplicationsForFile(const QString& filePath);
     Q_INVOKABLE QVariantList getAllApplications();
@@ -23,6 +28,10 @@ public:
     Q_INVOKABLE QVariantMap getDefaultAppForFile(const QString& filePath);
     Q_INVOKABLE void openWith(const QString& filePath, const QString& desktopFilePath);
     Q_INVOKABLE void setDefaultApp(const QString& mimeType, const QString& desktopFileName);
+
+private:
+    explicit MimeService(QObject* parent = nullptr);
+
 };
 
 } // namespace prism::core

--- a/src/core/networkmanager.hpp
+++ b/src/core/networkmanager.hpp
@@ -21,7 +21,6 @@ class NetworkManager : public QObject {
     Q_PROPERTY(QStringList supportedSchemes READ supportedSchemes CONSTANT)
 
 public:
-    explicit NetworkManager(QObject* parent = nullptr);
     ~NetworkManager() override = default;
 
     static NetworkManager* instance();
@@ -50,6 +49,7 @@ signals:
     void unmounted(const QString& path);
 
 private:
+    explicit NetworkManager(QObject* parent = nullptr);
     void handleMountProcessFinished(int exitCode, QProcess::ExitStatus exitStatus, const QString& uri, bool saveBookmark);
     QString resolveGvfsPath(const QString& uri) const;
 

--- a/src/core/papiruswatcher.hpp
+++ b/src/core/papiruswatcher.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QFileSystemWatcher>
 #include <QObject>
 #include <QStringList>
@@ -18,10 +21,12 @@ class PapirusWatcher : public QObject {
     Q_PROPERTY(bool isAvailable READ isAvailable CONSTANT)
 
 public:
-    explicit PapirusWatcher(QObject* parent = nullptr);
     ~PapirusWatcher() override = default;
 
     static PapirusWatcher* instance();
+    static PapirusWatcher* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] QString currentColor() const;
     [[nodiscard]] QStringList availableColors() const;
@@ -38,6 +43,7 @@ private slots:
     void onDebounceTimeout();
 
 private:
+    explicit PapirusWatcher(QObject* parent = nullptr);
     void scanAndWatch();
     void addPathIfValid(const QString& path, bool isDir);
     QString readColorFromKeepFile(const QString& filePath) const;

--- a/src/core/placesmodel.hpp
+++ b/src/core/placesmodel.hpp
@@ -46,7 +46,6 @@ public:
     };
     Q_ENUM(PlaceRoles)
 
-    explicit PlacesModel(QObject* parent = nullptr);
     ~PlacesModel() override = default;
 
     static PlacesModel* instance();
@@ -85,6 +84,7 @@ signals:
     void countChanged();
 
 private:
+    explicit PlacesModel(QObject* parent = nullptr);
     void loadHiddenPlaces();
     void saveHiddenPlaces();
     void loadStandardPlaces();

--- a/src/core/runnergame.hpp
+++ b/src/core/runnergame.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QVariantList>
 #include <QVariantMap>
@@ -75,10 +78,12 @@ public:
     };
     Q_ENUM(ObstacleType)
 
-    explicit RunnerGame(QObject* parent = nullptr);
     ~RunnerGame() override = default;
 
     static RunnerGame* instance();
+    static RunnerGame* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] int state() const { return m_state; }
     [[nodiscard]] int score() const { return m_score; }
@@ -125,6 +130,7 @@ private slots:
     void gameLoop();
 
 private:
+    explicit RunnerGame(QObject* parent = nullptr);
     void updatePhysics(qreal framesElapsed, qreal dt);
     void updateObstacles(qreal framesElapsed, qreal dt);
     void updateClouds(qreal framesElapsed, qreal dt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[]) {
 
     auto* appIntegration = prism::core::AppIntegration::instance();
     auto* papirusWatcher = prism::core::PapirusWatcher::instance();
-    auto* placesModel = new prism::core::PlacesModel(&app);
+    auto* placesModel = prism::core::PlacesModel::instance();
     auto* driveManager = new prism::core::DriveManager(&app);
     auto* networkManager = prism::core::NetworkManager::instance();
 


### PR DESCRIPTION
## The actual cause behind the upload task

This is the root of both things you reported, and it is why my earlier attempts only moved the symptom around.

Every one of these classes declares `QML_SINGLETON` *and* a public constructor. Qt default constructs the singleton rather than calling `create()`, so two objects exist: the one the QML engine made, and the one `instance()` returns.

Instrumented on current main, printing every reference in one run:

```
instance() / contextProperty = 0x5644b2d900e0
OperationsModal.qml sees       0x5644b44909c0
main.qml sees                  0x5644b44909c0
```

`create()` never prints. It is not called.

That splits the upload in half. `FileOperations.uploadToCatbox` runs on the QML object and sets `running` there, which is what put the card on screen. `CatboxUploader` writes its progress and its completed task through `FileOperations::instance()`, the other object, so nothing ever cleared the card and no completed entry ever appeared.

It also explains what the previous change did. Removing the up-front `setRunning(true)` removed the only write that reached the object QML displays, so the task stopped appearing at all. The lifecycle reasoning in that PR was right; it was operating on an object nobody was looking at.

The same split affects `CatboxUploader` itself, so `isUploading` and the cancel button in the modal were never connected to the uploader doing the work, and `AppController`, `AppIntegration`, `PapirusWatcher`, `MimeService`, `GitManager`, `IconCatalog`, `NetworkManager` and `RunnerGame`.

## Change

Make the constructor private, which leaves `create()` as the only way to build the type, and add `create()` to the classes that lacked one. Nothing constructs any of them outside `instance()`, so this compiles unchanged elsewhere.

After the change, in the same instrumented run, every reference resolves to one pointer and `create()` is called once.

## Verified

Driving the real application headless against a local server standing in for the API, reading `FileOperations.completedTasks.length` from QML on a timer: before the change it stays at zero through a successful upload, after it goes to one, and a rejected path adds its own entry.

## Note on the other two

#26 stays useful on top of this: the completed task check drops a repeat with no time bound, so uploading the same file twice still records it once; `cancelUpload` dereferences the reply pointer that `abort()` already cleared; and `onReplyFinished` can strand the queue. Those are real regardless of which object they run on. This one should go first.
