### PR TITLE
fix: repair the segmented button row

### DIFF
--- a/qml/components/controls/ButtonRow.qml
+++ b/qml/components/controls/ButtonRow.qml
@@ -14,11 +14,11 @@ RowLayout {
     property string iconKey: "icon"
     property var isSelected: null // optional custom callback: (modelData, index) => bool
     property bool multiSelect: false
+    property int buttonHeight: 40
 
     signal selected(var value, int index)
 
     spacing: 2
-    implicitHeight: 40
 
     Repeater {
         id: repeater
@@ -61,15 +61,18 @@ RowLayout {
             last: index === repeater.count - 1
 
             Layout.fillWidth: true
-            Layout.fillHeight: true
-            implicitHeight: root.implicitHeight
+            Layout.preferredHeight: root.buttonHeight
+            implicitHeight: root.buttonHeight
 
             color: itemRect.checked
                 ? Colours.palette.m3primaryContainer
                 : (itemHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
 
             Behavior on color {
-                Anim { type: Anim.FastEffects }
+            CAnim {
+                duration: Tokens.anim.durations.expressiveFastEffects
+                easing: Tokens.anim.expressiveFastEffects
+            }
             }
 
             StateLayer {

--- a/qml/components/controls/ButtonRowItem.qml
+++ b/qml/components/controls/ButtonRowItem.qml
@@ -23,7 +23,10 @@ ConnectedRect {
         : (itemHover.containsMouse ? Colours.tPalette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainer)
 
     Behavior on color {
-        Anim { type: Anim.FastEffects }
+        CAnim {
+            duration: Tokens.anim.durations.expressiveFastEffects
+            easing: Tokens.anim.expressiveFastEffects
+        }
     }
 
     StateLayer {


### PR DESCRIPTION
## Two defects, one component

### Buttons turn black once you click them

`ButtonRowItem.qml` and `ButtonRow.qml` both declare

```qml
Behavior on color {
    Anim { type: Anim.FastEffects }
}
```

`Anim` is a `NumberAnimation`. It cannot interpolate a colour. The first time a button changes state the Behavior hands the property to that animation, which writes an invalid value rendering as black, and the binding is destroyed, so it never recovers.

The label goes with it. A checked button sets its text to `m3onPrimaryContainer`, dark by design because the container is light. On black it is invisible.

Reproduced by toggling a Details View Column off and on again: the button stays black and unlabelled while its untouched neighbours are fine. The same row is used for the tab switcher in the properties dialog and the git dialog, which is where it was first noticed.

Every other colour Behavior in the project uses `CAnim`. These two were the exceptions. They now use it as well, with the fast effect duration and curve so the intended timing is kept.

### The row stretched to fill the git dialog

`ButtonRow` declared `implicitHeight: 40` on the root while each delegate declared `Layout.fillHeight: true` together with `implicitHeight: root.implicitHeight`. A layout derives its implicit height from its children, and here the child was reading the value being derived from it.

In the preferences dialog the row sat between items that pinned it, so it looked right. In the git dialog the column gives it no height of its own and it filled the whole dialog as one light rectangle.

The row now exposes `buttonHeight`, which the delegate reads as its preferred height, and the root no longer assigns its own implicit height.

## Verified

Rendered before and after, headless: the segmented row in the git dialog is 40 px again rather than the full height, and a column button toggled off and back on returns to its checked appearance with its label instead of going black. Both the checked and unchecked appearances were checked.
