### PR TITLE
fix: expose the token scale so button radii are not NaN

### DIFF
--- a/src/config/tokens.hpp
+++ b/src/config/tokens.hpp
@@ -14,6 +14,8 @@ class RoundingTokens : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
 
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY valuesChanged)
+
 #define TOKEN_PROP(name, defaultVal) \
     Q_PROPERTY(int name READ name NOTIFY valuesChanged) \
 public: \
@@ -37,7 +39,13 @@ private: \
 public:
     explicit RoundingTokens(QObject* parent = nullptr) : QObject(parent) {}
 
-    void setScale(qreal scale) { m_scale = scale; emit valuesChanged(); }
+    [[nodiscard]] qreal scale() const { return m_scale; }
+    void setScale(qreal scale) {
+        if (qFuzzyCompare(m_scale, scale))
+            return;
+        m_scale = scale;
+        emit valuesChanged();
+    }
     void loadJson(const QJsonObject& json);
 
 signals:
@@ -50,6 +58,8 @@ private:
 class SpacingTokens : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
+
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY valuesChanged)
 
 #define TOKEN_PROP(name, defaultVal) \
     Q_PROPERTY(int name READ name NOTIFY valuesChanged) \
@@ -73,7 +83,13 @@ private: \
 public:
     explicit SpacingTokens(QObject* parent = nullptr) : QObject(parent) {}
 
-    void setScale(qreal scale) { m_scale = scale; emit valuesChanged(); }
+    [[nodiscard]] qreal scale() const { return m_scale; }
+    void setScale(qreal scale) {
+        if (qFuzzyCompare(m_scale, scale))
+            return;
+        m_scale = scale;
+        emit valuesChanged();
+    }
     void loadJson(const QJsonObject& json);
 
 signals:
@@ -86,6 +102,8 @@ private:
 class PaddingTokens : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
+
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY valuesChanged)
 
 #define TOKEN_PROP(name, defaultVal) \
     Q_PROPERTY(int name READ name NOTIFY valuesChanged) \
@@ -109,7 +127,13 @@ private: \
 public:
     explicit PaddingTokens(QObject* parent = nullptr) : QObject(parent) {}
 
-    void setScale(qreal scale) { m_scale = scale; emit valuesChanged(); }
+    [[nodiscard]] qreal scale() const { return m_scale; }
+    void setScale(qreal scale) {
+        if (qFuzzyCompare(m_scale, scale))
+            return;
+        m_scale = scale;
+        emit valuesChanged();
+    }
     void loadJson(const QJsonObject& json);
 
 signals:
@@ -122,6 +146,8 @@ private:
 class AnimDurationTokens : public QObject {
     Q_OBJECT
     QML_ANONYMOUS
+
+    Q_PROPERTY(qreal scale READ scale WRITE setScale NOTIFY valuesChanged)
 
 #define TOKEN_PROP(name, defaultVal) \
     Q_PROPERTY(int name READ name NOTIFY valuesChanged) \
@@ -147,7 +173,13 @@ private: \
 public:
     explicit AnimDurationTokens(QObject* parent = nullptr) : QObject(parent) {}
 
-    void setScale(qreal scale) { m_scale = scale; emit valuesChanged(); }
+    [[nodiscard]] qreal scale() const { return m_scale; }
+    void setScale(qreal scale) {
+        if (qFuzzyCompare(m_scale, scale))
+            return;
+        m_scale = scale;
+        emit valuesChanged();
+    }
     void loadJson(const QJsonObject& json);
 
 signals:


### PR DESCRIPTION
## Problem

`ButtonBase.qml` and `SplitButton.qml` compute their pill radius as

```qml
implicitHeight / 2 * Math.min(1, Tokens.rounding.scale)
```

`scale` is not exposed to QML. In `tokens.hpp` it is a plain C++ setter with a private member and no `Q_PROPERTY`, so the expression reads `undefined`, `Math.min(1, undefined)` is `NaN`, and the binding assigns `radius: NaN`.

Every button in the application is affected, since `ButtonBase` is the shared base. It is most visible on `SplitButton`, which combines that radius with valid per-corner radii (`topRightRadius: Tokens.rounding.medium / 2`); an invalid `radius` alongside valid corners produces malformed shapes rather than simply falling back.

Reported as the split button looking wrong in the preferences dialog, with a dark sliver at the seam and a distorted corner.

## Change

Expose `scale` as a property on the four token groups that carry one — rounding, spacing, padding and animation durations — so the existing QML expressions evaluate as intended. `setScale` also skips the notification when the value is unchanged, since it emits `valuesChanged` for the whole group.

## Verified

Rendered before and after. Before, the split button draws with square corners in a software render and malformed ones on hardware; after, it is a pill with the small radius at the seam that the code intends.
