### PR TITLE
fix: stop the settings and properties dialogs cramping their content

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -133,10 +133,10 @@ MouseArea {
         id: modalCard
 
         anchors.centerIn: parent
-        width: Math.min(parent.width - 32, 580)
-        height: Math.min(parent.height - 32, 560)
-        implicitWidth: 580
-        implicitHeight: 560
+        width: Math.min(parent.width - 64, 760)
+        height: Math.min(parent.height - 64, 660)
+        implicitWidth: 760
+        implicitHeight: 660
 
         radius: Tokens.rounding.large
         color: Colours.palette.m3surfaceContainerHigh
@@ -158,7 +158,7 @@ MouseArea {
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: Tokens.padding.large
-            spacing: Tokens.spacing.medium
+            spacing: Tokens.spacing.large
 
             // Header
             RowLayout {
@@ -239,6 +239,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Startup Location")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -302,6 +303,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("File Display & Navigation")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -349,6 +351,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Thumbnail Generation")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                                 opacity: AppController.thumbnailsEnabled ? 1 : 0.4
@@ -370,6 +373,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Theme & Icons")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -452,6 +456,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Layout & View Mode")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -470,6 +475,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Details View Columns")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -521,6 +527,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Date & Time")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -539,6 +546,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Sidebar Navigation")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -570,6 +578,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Sorting & Organization")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -630,6 +639,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Context Menu Visibility")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -738,6 +748,7 @@ MouseArea {
 
                             StyledText {
                                 text: qsTr("Custom Context Actions & Scripts")
+                                Layout.topMargin: Tokens.spacing.small
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
@@ -765,6 +776,13 @@ MouseArea {
                         }
                     }
                 }
+            }
+
+            StyledRect {
+                Layout.fillWidth: true
+                Layout.topMargin: Tokens.spacing.extraSmall
+                implicitHeight: 1
+                color: Qt.alpha(Colours.palette.m3outlineVariant, 0.6)
             }
 
             // Bottom Action Buttons

--- a/qml/components/dialogs/PropertiesModal.qml
+++ b/qml/components/dialogs/PropertiesModal.qml
@@ -63,10 +63,10 @@ MouseArea {
         id: dialog
 
         anchors.centerIn: parent
-        width: Math.min(parent.width - 32, 480)
-        height: Math.min(parent.height - 32, 560)
-        implicitWidth: 480
-        implicitHeight: 560
+        width: Math.min(parent.width - 64, 620)
+        height: Math.min(parent.height - 64, 600)
+        implicitWidth: 620
+        implicitHeight: 600
 
         radius: Tokens.rounding.large
         color: Colours.palette.m3surfaceContainer
@@ -149,31 +149,34 @@ MouseArea {
                 RowLayout {
                     Layout.fillWidth: true
                     StyledText { Layout.preferredWidth: 110; text: meta.isDir ? qsTr("Contents:") : qsTr("Size:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
-                    StyledText { Layout.fillWidth: true; text: meta.isDir ? qsTr("%1 items").arg(meta.itemCount) : meta.formattedSize; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface }
+                    StyledText { Layout.fillWidth: true; text: meta.isDir ? qsTr("%1 items").arg(meta.itemCount) : meta.formattedSize; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface; elide: Text.ElideRight }
                 }
                 RowLayout {
                     visible: meta.imageDimensions.length > 0
                     Layout.fillWidth: true
                     StyledText { Layout.preferredWidth: 110; text: qsTr("Dimensions:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
-                    StyledText { Layout.fillWidth: true; text: meta.imageDimensions; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface }
+                    StyledText { Layout.fillWidth: true; text: meta.imageDimensions; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface; elide: Text.ElideRight }
                 }
 
                 Rectangle { Layout.fillWidth: true; height: 1; color: Colours.palette.m3outlineVariant; opacity: 0.5 }
 
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Created:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
-                    StyledText { Layout.fillWidth: true; text: meta.formattedCreated; font: Tokens.font.body.small; color: Colours.palette.m3onSurface }
+                    Layout.alignment: Qt.AlignTop
+                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Created:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.fillWidth: true; text: meta.formattedCreated; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Modified:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
-                    StyledText { Layout.fillWidth: true; text: meta.formattedModified; font: Tokens.font.body.small; color: Colours.palette.m3onSurface }
+                    Layout.alignment: Qt.AlignTop
+                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Modified:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.fillWidth: true; text: meta.formattedModified; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Accessed:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
-                    StyledText { Layout.fillWidth: true; text: meta.formattedAccessed; font: Tokens.font.body.small; color: Colours.palette.m3onSurface }
+                    Layout.alignment: Qt.AlignTop
+                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Accessed:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.fillWidth: true; text: meta.formattedAccessed; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
 
                 RowLayout {

--- a/qml/components/tabs/M3TopTabBar.qml
+++ b/qml/components/tabs/M3TopTabBar.qml
@@ -10,7 +10,7 @@ Item {
     property int currentIndex: 0
     signal tabSelected(int index)
 
-    implicitHeight: 60
+    implicitHeight: 64
     implicitWidth: 400
 
     readonly property int count: root.model ? root.model.length : 0
@@ -51,7 +51,8 @@ Item {
 
                 ColumnLayout {
                     anchors.centerIn: parent
-                    spacing: 2
+                    width: parent.width - Tokens.padding.medium * 2
+                    spacing: 3
 
                     MaterialIcon {
                         Layout.alignment: Qt.AlignHCenter
@@ -66,6 +67,9 @@ Item {
 
                     StyledText {
                         Layout.alignment: Qt.AlignHCenter
+                        Layout.maximumWidth: parent.width
+                        horizontalAlignment: Text.AlignHCenter
+                        elide: Text.ElideRight
                         text: tabBtn.modelData.label
                         color: tabBtn.isCurrent ? Colours.palette.m3primary : (stateLayer.containsMouse ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant)
                         font: tabBtn.isCurrent


### PR DESCRIPTION
## Problem

Both dialogs put more content into their cards than the cards can hold.

**Preferences**, 580 px wide, carries four tabs. `M3TopTabBar` gives each tab an equal share of the width with no horizontal padding and no eliding, so the labels ran into one another: Context Menu and Scripts & Tools touched, and Scripts & Tools reached the card edge. Row subtexts were cut mid word, `Ask before deleting files without using the trash (Shift…`.

**Properties**, 480 px wide, has three timestamp rows built as

```qml
StyledText { Layout.fillWidth: true; text: meta.formattedCreated; ... }
```

with neither `elide` nor `wrapMode`. `Text` does not clip itself, so a long locale timestamp such as `Mittwoch, 8. Juli 2026 18:40:43 Mitteleuropäische Sommerzeit` renders straight past the edge of the card. The rows above it set `elide` and stay inside; these three were missed.

## Change

Preferences goes to 760 px, properties to 620 px. Both had subtexts that only fit at that width.

Tab labels get padding, centre alignment and eliding, so a long one truncates inside its own cell instead of reaching into the next.

The timestamps wrap rather than elide. Truncating them would drop the time zone, and the dialog had plenty of unused vertical space. Their labels align to the top so a wrapped value still lines up with its label. The remaining value rows that lacked one get `elide` as a bound.

Section headings get space above them, the outer spacing goes from medium to large, and a separator sits above the action buttons, which previously abutted the last row.

## Not changed

The animations are untouched: the tab indicator slide, the page transition, the colour transitions and the open scale all behave as before.

## Verified

Rendered before and after for both dialogs and for each preferences tab.
