### PR TITLE
fix: write plural forms out instead of relying on qsTr(%n)

### DIFF
--- a/qml/components/dialogs/BulkRenameModal.qml
+++ b/qml/components/dialogs/BulkRenameModal.qml
@@ -142,7 +142,9 @@ MouseArea {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: qsTr("Rename %n item(s)", "", root.targets.length)
+                    text: root.targets.length === 1
+                        ? qsTr("Rename 1 item")
+                        : qsTr("Rename %1 items").arg(root.targets.length)
                     color: Colours.palette.m3onSurface
                     font: Tokens.font.title.medium
                 }
@@ -381,7 +383,9 @@ MouseArea {
                     Layout.fillWidth: true
                     text: root.hasProblem
                         ? qsTr("Resolve the highlighted names to continue")
-                        : qsTr("%n name(s) will change", "", root.changedCount)
+                        : (root.changedCount === 1
+                            ? qsTr("1 name will change")
+                            : qsTr("%1 names will change").arg(root.changedCount))
                     color: root.hasProblem ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
                     font: Tokens.font.body.small
                     elide: Text.ElideRight

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -707,7 +707,9 @@ void FileOperations::bulkRename(const QStringList& paths, const QStringList& new
     m_redoStack.clear();
     emit undoStackChanged();
 
-    emit operationFinished(true, tr("Renamed %n item(s)", "", static_cast<int>(sources.size())));
+    emit operationFinished(true, sources.size() == 1
+                                     ? tr("Renamed 1 item")
+                                     : tr("Renamed %1 items").arg(sources.size()));
 }
 
 void FileOperations::createDirectory(const QString& parentDir, const QString& name) {


### PR DESCRIPTION
## Problem

The bulk rename dialog reads `Rename 3 item(s)` and `0 name(s) will change`.

`qsTr("Rename %n item(s)", "", n)` picks a plural form out of a translation catalogue. With none loaded Qt falls back to the source string, substituting the count and leaving `(s)` in place. It never reads correctly in the shipped build.

Three strings are affected, all mine from the bulk rename work: the dialog title, the count above the buttons, and the completion message in `bulkRename`.

## Change

Spell both forms out, which is what `ConfirmDeleteModal` already does for the same situation. Should a catalogue be added later, `%n` can come back for the languages that need more than two forms.
