### PR TITLE
fix: connect the git panel to the directory being viewed

### DIFF
--- a/qml/components/dialogs/GitModal.qml
+++ b/qml/components/dialogs/GitModal.qml
@@ -32,10 +32,10 @@ MouseArea {
         id: dialog
 
         anchors.centerIn: parent
-        width: Math.min(parent.width - 32, 500)
-        height: Math.min(parent.height - 32, 560)
-        implicitWidth: 500
-        implicitHeight: 560
+        width: Math.min(parent.width - 64, 580)
+        height: Math.min(parent.height - 64, 600)
+        implicitWidth: 580
+        implicitHeight: 600
 
         radius: Tokens.rounding.large
         color: Colours.palette.m3surfaceContainer
@@ -68,18 +68,24 @@ MouseArea {
 
                 ColumnLayout {
                     Layout.fillWidth: true
+                    Layout.rightMargin: Tokens.spacing.small
                     spacing: 2
 
                     StyledText {
+                        Layout.fillWidth: true
                         text: qsTr("Git Repository")
                         font: Tokens.font.title.medium
                         color: Colours.palette.m3onSurface
+                        elide: Text.ElideRight
                     }
 
                     StyledText {
+                        Layout.fillWidth: true
+                        visible: GitManager.branchName.length > 0
                         text: qsTr("Current branch: %1").arg(GitManager.branchName)
                         font: Tokens.font.label.medium
                         color: Colours.palette.m3tertiary
+                        elide: Text.ElideMiddle
                     }
                 }
 
@@ -201,6 +207,18 @@ MouseArea {
                         }
                     }
                 }
+
+                StyledText {
+                    anchors.centerIn: parent
+                    width: parent.width - Tokens.padding.large * 2
+                    visible: branchesList.count === 0
+                    text: qsTr("No branches found in this repository")
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.body.small
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                }
+
             }
 
             // Tab 1: Commits History Feed
@@ -273,6 +291,18 @@ MouseArea {
                         }
                     }
                 }
+
+                StyledText {
+                    anchors.centerIn: parent
+                    width: parent.width - Tokens.padding.large * 2
+                    visible: commitsList.count === 0
+                    text: qsTr("No commits yet")
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.body.small
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.WordWrap
+                }
+
             }
 
             // Close Button

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -495,6 +495,12 @@ ApplicationWindow {
         }
 
         // Git Repository Modal
+        Binding {
+            target: GitManager
+            property: "currentPath"
+            value: TabManager.currentTab ? TabManager.currentTab.currentPath : ""
+        }
+
         GitModal {
             id: gitModal
         }


### PR DESCRIPTION
## The git panel never had a repository

`GitManager.currentPath` is not assigned anywhere, in QML or in C++. It stays empty, so `checkRepo` takes its early return and `isGitRepo` is false no matter where you are.

Two things depend on that. The dialog shows `Branches (0)` and `Recent Commits (0)` in every directory, including inside a repository. And the branch indicator in the status bar is gated on `GitManager.isGitRepo`, so it never appears either.

Binding the property to the active tab's path fixes both. `setCurrentPath` already calls `checkRepo`, and that does its work through `QtConcurrent`, so following every directory change costs nothing on the GUI thread.

Verified against this repository: 32 branches, 20 commits, and the branch name in the header, where before it was empty.

## The dialog also had no empty state

Outside a repository the list area was simply blank, which looks the same as one that failed to load. Both lists now say what is missing.

The header put the title, the branch line and the pull and fetch buttons in one row with the title column free to shrink, so the title ran up against the buttons. The title elides now, the branch line hides when there is no branch rather than showing `Current branch:` with nothing after it, and the card is 580 px instead of 500.

## Note

While testing this I noticed that a directory passed on the command line does not end up in the tab — `prism ~/src/PrismFiles` still opens at home. That looks like a separate ordering problem between the startup argument and the restored session path, and is not touched here.
