### PR TITLE
fix: give the open with list a soft edge and a footer separator

### DIFF
--- a/qml/components/dialogs/OpenWithModal.qml
+++ b/qml/components/dialogs/OpenWithModal.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import "../"
+import "../containers"
 import "../controls"
 import prism
 
@@ -142,12 +143,17 @@ MouseArea {
             }
 
             // Applications List
-            ListView {
+            VerticalFadeListView {
                 id: appListView
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
                 spacing: 6
+                boundsBehavior: Flickable.StopAtBounds
+
+                ScrollBar.vertical: StyledScrollBar {
+                    flickable: appListView
+                }
 
                 model: root.filteredApps
 
@@ -242,6 +248,13 @@ MouseArea {
                         }
                     }
                 }
+            }
+
+            StyledRect {
+                Layout.fillWidth: true
+                Layout.topMargin: Tokens.spacing.extraSmall
+                implicitHeight: 1
+                color: Qt.alpha(Colours.palette.m3outlineVariant, 0.6)
             }
 
             // Always use as default checkbox


### PR DESCRIPTION
## Problem

The application list in Open With is a plain `ListView` with `clip: true`. A row that does not fit is sliced through the middle with a hard edge, and it sits directly against the always use this application checkbox with nothing between them, so the cut row reads as broken layout rather than as content continuing below.

There is no scroll bar either, so nothing indicates the list can be scrolled.

## Change

Use `VerticalFadeListView`, which the places manager and the details view already use, so the cut fades instead. Add the scroll bar those lists have, and a separator above the footer so the list and the controls below it are distinct.
