### PR TITLE
feat: apply permissions to a folder's contents

### DIFF
--- a/qml/components/dialogs/PropertiesModal.qml
+++ b/qml/components/dialogs/PropertiesModal.qml
@@ -286,11 +286,28 @@ MouseArea {
                     StyledCheckBox { id: oX; checked: meta.permissions.length >= 9 && meta.permissions[8] === 'x' }
                 }
 
+                StyledCheckBox {
+                    id: recursiveCheck
+                    Layout.fillWidth: true
+                    Layout.topMargin: Tokens.spacing.small
+                    visible: meta.isDir
+                    text: qsTr("Apply to enclosed files and folders")
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    visible: recursiveCheck.visible && recursiveCheck.checked
+                    text: qsTr("Folders keep the execute bit wherever they are readable, so they stay open-able.")
+                    color: Colours.palette.m3outline
+                    font: Tokens.font.label.small
+                    wrapMode: Text.WordWrap
+                }
+
                 TextButton {
                     Layout.alignment: Qt.AlignRight
                     type: ButtonBase.Tonal
                     text: qsTr("Apply Permissions")
-                    onClicked: meta.applyPermissions(uR.checked, uW.checked, uX.checked, gR.checked, gW.checked, gX.checked, oR.checked, oW.checked, oX.checked)
+                    onClicked: meta.applyPermissions(uR.checked, uW.checked, uX.checked, gR.checked, gW.checked, gX.checked, oR.checked, oW.checked, oX.checked, meta.isDir && recursiveCheck.checked)
                 }
 
                 Item { Layout.fillHeight: true }

--- a/src/core/filemetadata.cpp
+++ b/src/core/filemetadata.cpp
@@ -201,6 +201,16 @@ void FileMetadata::calculateChecksums() {
     });
 }
 
+static QFile::Permissions traversablePermissions(QFile::Permissions perms) {
+    if (perms & QFile::ReadUser)
+        perms |= QFile::ExeUser;
+    if (perms & QFile::ReadGroup)
+        perms |= QFile::ExeGroup;
+    if (perms & QFile::ReadOther)
+        perms |= QFile::ExeOther;
+    return perms;
+}
+
 bool FileMetadata::applyPermissions(int userRead, int userWrite, int userExec,
                                     int groupRead, int groupWrite, int groupExec,
                                     int otherRead, int otherWrite, int otherExec,
@@ -218,9 +228,32 @@ bool FileMetadata::applyPermissions(int userRead, int userWrite, int userExec,
     if (otherWrite) perms |= QFile::WriteOther;
     if (otherExec) perms |= QFile::ExeOther;
 
-    bool success = QFile::setPermissions(m_path, perms);
-    reload();
-    return success;
+    if (!recursive) {
+        const bool success = QFile::setPermissions(m_path, perms);
+        reload();
+        return success;
+    }
+
+    const QString root = m_path;
+    (void)QtConcurrent::run([this, root, perms]() {
+        QFile::setPermissions(root, traversablePermissions(perms));
+
+        QDirIterator it(root, QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System,
+                        QDirIterator::Subdirectories);
+        while (it.hasNext()) {
+            const QString entry = it.next();
+            const QFileInfo info = it.fileInfo();
+            if (info.isSymLink())
+                continue;
+            QFile::setPermissions(entry, info.isDir() ? traversablePermissions(perms) : perms);
+        }
+
+        QMetaObject::invokeMethod(this, [this]() {
+            reload();
+        });
+    });
+
+    return true;
 }
 
 } // namespace prism::core


### PR DESCRIPTION
## Problem

`FileMetadata::applyPermissions` has taken a `bool recursive = false` since it was written, and the body never reads it:

```cpp
bool success = QFile::setPermissions(m_path, perms);
reload();
return success;
```

The properties dialog does not pass it either, so changing a folder's permissions has always affected the folder alone. Thunar offers this through `misc-recursive-permissions`.

## Change

Implement the recursion, and offer it as a checkbox that appears for directories.

**Directories get the execute bit wherever the matching read bit is set.** Applying a plain file mode recursively is the trap here: `rw-r--r--` on a directory makes it unreadable to its own owner, and a tree treated that way has to be repaired from a terminal. This is the same rule `chmod` exposes as `X`, and the dialog says so when the box is ticked.

**Symbolic links are skipped.** `QFile::setPermissions` on a link changes its target, which may be anywhere on the system.

**The walk runs on a pool thread.** A deep tree would otherwise hold the GUI thread for its whole duration, and the properties dialog offers no progress. `reload()` is posted back when it finishes.

## Verified

On a tree containing a nested directory, a file in it, and a symlink to a file outside with mode 777, applying `rw-r--r--` recursively:

```
drwxr-xr-x  /tmp/permtest
-rw-r--r--  /tmp/permtest/datei.txt
drwxr-xr-x  /tmp/permtest/unter
-rwxrwxrwx  /tmp/permziel      <- link target, untouched
```
