### PR TITLE
feat: open a folder in a new tab with the middle button

### DIFF
--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -81,6 +81,7 @@ Item {
     }
 
     signal openItem(var item)
+    signal openItemInNewTab(var item)
     signal itemContextMenu(var item, real mouseX, real mouseY)
     signal blankContextMenu(real mouseX, real mouseY)
     signal filesDropped(var sourceFiles, string targetDir, real mouseX, real mouseY)
@@ -440,7 +441,7 @@ Item {
                     id: compHover
                     anchors.fill: parent
                     hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
 
                     property real pressX: 0
                     property real pressY: 0
@@ -448,6 +449,14 @@ Item {
 
                     onPressed: mouse => {
                         root.notifyFocus();
+
+                        if (mouse.button === Qt.MiddleButton) {
+
+                            mouse.accepted = true;
+
+                            return;
+
+                        }
                         pressX = mouse.x;
                         pressY = mouse.y;
                         isDragging = false;
@@ -474,6 +483,11 @@ Item {
 
                     onClicked: mouse => {
                         root.notifyFocus();
+                        if (mouse.button === Qt.MiddleButton) {
+                            if (modelData && modelData.isDir)
+                                root.openItemInNewTab(modelData);
+                            return;
+                        }
                         if (isDragging || dragSelectArea.isSelecting) return;
                         if (mouse.button === Qt.BackButton || mouse.button === Qt.ExtraButton1) {
                             if (root.activeTab && root.activeTab.canGoBack) root.activeTab.goBack();

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -86,6 +86,7 @@ Item {
     }
 
     signal openItem(var item)
+    signal openItemInNewTab(var item)
     signal itemContextMenu(var item, real mouseX, real mouseY)
     signal blankContextMenu(real mouseX, real mouseY)
     signal filesDropped(var sourceFiles, string targetDir, real mouseX, real mouseY)
@@ -723,7 +724,7 @@ Item {
                     id: rowHover
                     anchors.fill: parent
                     hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
 
                     property real pressX: 0
                     property real pressY: 0
@@ -731,6 +732,14 @@ Item {
 
                     onPressed: mouse => {
                         root.notifyFocus();
+
+                        if (mouse.button === Qt.MiddleButton) {
+
+                            mouse.accepted = true;
+
+                            return;
+
+                        }
                         pressX = mouse.x;
                         pressY = mouse.y;
                         isDragging = false;
@@ -757,6 +766,11 @@ Item {
 
                     onClicked: mouse => {
                         root.notifyFocus();
+                        if (mouse.button === Qt.MiddleButton) {
+                            if (modelData && modelData.isDir)
+                                root.openItemInNewTab(modelData);
+                            return;
+                        }
                         if (isDragging || dragSelectArea.isSelecting) return;
                         if (mouse.button === Qt.BackButton || mouse.button === Qt.ExtraButton1) {
                             if (root.activeTab && root.activeTab.canGoBack) root.activeTab.goBack();

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -88,6 +88,7 @@ Item {
     }
 
     signal openItem(var item)
+    signal openItemInNewTab(var item)
     signal itemContextMenu(var item, real mouseX, real mouseY)
     signal blankContextMenu(real mouseX, real mouseY)
     signal filesDropped(var sourceFiles, string targetDir, real mouseX, real mouseY)
@@ -463,7 +464,7 @@ Item {
                     id: itemHover
                     anchors.fill: parent
                     hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.BackButton | Qt.ForwardButton | Qt.ExtraButton1 | Qt.ExtraButton2
 
                     property real pressX: 0
                     property real pressY: 0
@@ -471,6 +472,14 @@ Item {
 
                     onPressed: mouse => {
                         root.notifyFocus();
+
+                        if (mouse.button === Qt.MiddleButton) {
+
+                            mouse.accepted = true;
+
+                            return;
+
+                        }
                         pressX = mouse.x;
                         pressY = mouse.y;
                         isDragging = false;
@@ -497,6 +506,11 @@ Item {
 
                     onClicked: mouse => {
                         root.notifyFocus();
+                        if (mouse.button === Qt.MiddleButton) {
+                            if (modelData && modelData.isDir)
+                                root.openItemInNewTab(modelData);
+                            return;
+                        }
                         if (isDragging || dragSelectArea.isSelecting) return;
                         if (mouse.button === Qt.BackButton || mouse.button === Qt.ExtraButton1) {
                             if (root.activeTab && root.activeTab.canGoBack) root.activeTab.goBack();

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -61,6 +61,7 @@ StyledRect {
     signal createNewFolder()
     signal createNewFile()
     signal itemOpened(var item, int pane)
+    signal itemOpenedInNewTab(var item)
 
     color: Colours.tPalette.m3surfaceContainer
 
@@ -263,6 +264,7 @@ StyledRect {
             paneIndex: 0
             zoomSize: root.zoomSize
             onOpenItem: item => root.handleOpen(item, 0)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 0;
                 root.itemContextMenu(item, x, y);
@@ -286,6 +288,7 @@ StyledRect {
             activeTab: root.activeTab
             paneIndex: 0
             onOpenItem: item => root.handleOpen(item, 0)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 0;
                 root.itemContextMenu(item, x, y);
@@ -309,6 +312,7 @@ StyledRect {
             activeTab: root.activeTab
             paneIndex: 0
             onOpenItem: item => root.handleOpen(item, 0)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 0;
                 root.itemContextMenu(item, x, y);
@@ -333,6 +337,7 @@ StyledRect {
             paneIndex: 1
             zoomSize: root.zoomSize
             onOpenItem: item => root.handleOpen(item, 1)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 1;
                 root.itemContextMenu(item, x, y);
@@ -356,6 +361,7 @@ StyledRect {
             activeTab: root.activeTab
             paneIndex: 1
             onOpenItem: item => root.handleOpen(item, 1)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 1;
                 root.itemContextMenu(item, x, y);
@@ -379,6 +385,7 @@ StyledRect {
             activeTab: root.activeTab
             paneIndex: 1
             onOpenItem: item => root.handleOpen(item, 1)
+            onOpenItemInNewTab: item => root.itemOpenedInNewTab(item)
             onItemContextMenu: (item, x, y) => {
                 if (root.activeTab) root.activeTab.activePane = 1;
                 root.itemContextMenu(item, x, y);

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -242,6 +242,11 @@ ApplicationWindow {
                                 dropActionMenu.expanded = true;
                             }
 
+                            onItemOpenedInNewTab: item => {
+                                if (item && item.isDir)
+                                    TabManager.newTab(item.path);
+                            }
+
                             onItemOpened: (item, pane) => {
                                 AppIntegration.openWithDefault(item.path);
                             }


### PR DESCRIPTION
## Problem

The item mouse areas in all three views accept `LeftButton | RightButton | BackButton | ForwardButton | ExtraButton1 | ExtraButton2`. The middle button is not among them, so the standard gesture for opening a folder in a background tab does nothing at all.

Tabs and the action itself already exist — `openNewTab` is in the context menu and calls `TabManager.newTab`. Only the gesture is missing.

## Change

A separate `openItemInNewTab` signal on each view, routed through `SplitViewContainer` to `TabManager.newTab`.

It does not reuse `openItem`, because the container routes that one into the pane the click came from — `handleOpen(item, pane)` — which is the right behaviour for activation and the wrong one here.

Files ignore the middle click. Opening a document in a tab has no meaning, and Thunar behaves the same way.

The button is also claimed in `onPressed`, otherwise the press starts a rubber band selection before the click is delivered.

## Verified

Grid, details and compact all build and start clean. The signal chain was exercised by emitting `itemOpenedInNewTab` directly: tab count goes from 1 to 2 and the new tab lands on the given path. The button routing itself needs a real mouse and is for you to confirm.
