### PR TITLE
feat: optionally confirm moving files to the trash

### DIFF
--- a/qml/components/dialogs/ConfirmDeleteModal.qml
+++ b/qml/components/dialogs/ConfirmDeleteModal.qml
@@ -122,7 +122,7 @@ MouseArea {
                 }
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.medium
-                wrapMode: Text.WordWrap
+                wrapMode: Text.Wrap
             }
 
             RowLayout {

--- a/qml/components/dialogs/ConfirmDeleteModal.qml
+++ b/qml/components/dialogs/ConfirmDeleteModal.qml
@@ -9,6 +9,7 @@ MouseArea {
 
     property bool expanded: false
     property var targetPaths: []
+    property bool permanent: true
 
     signal confirmed(var paths)
 
@@ -93,14 +94,14 @@ MouseArea {
                 spacing: Tokens.spacing.small
 
                 MaterialIcon {
-                    text: "delete_forever"
-                    color: Colours.palette.m3error
+                    text: root.permanent ? "delete_forever" : "delete"
+                    color: root.permanent ? Colours.palette.m3error : Colours.palette.m3primary
                     fontStyle: Tokens.font.icon.medium
                 }
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: qsTr("Delete permanently")
+                    text: root.permanent ? qsTr("Delete permanently") : qsTr("Move to trash")
                     color: Colours.palette.m3onSurface
                     font: Tokens.font.title.medium
                 }
@@ -108,7 +109,17 @@ MouseArea {
 
             StyledText {
                 Layout.fillWidth: true
-                text: root.targetPaths.length === 1 ? qsTr("\"%1\" will be deleted permanently. This cannot be undone.").arg(root.targetPaths.length > 0 ? root.targetPaths[0].split("/").pop() : "") : qsTr("%n items will be deleted permanently. This cannot be undone.", "", root.targetPaths.length)
+                text: {
+                    const name = root.targetPaths.length > 0 ? root.targetPaths[0].split("/").pop() : "";
+                    if (root.permanent) {
+                        return root.targetPaths.length === 1
+                            ? qsTr("\"%1\" will be deleted permanently. This cannot be undone.").arg(name)
+                            : qsTr("%1 items will be deleted permanently. This cannot be undone.").arg(root.targetPaths.length);
+                    }
+                    return root.targetPaths.length === 1
+                        ? qsTr("\"%1\" will be moved to the trash.").arg(name)
+                        : qsTr("%1 items will be moved to the trash.").arg(root.targetPaths.length);
+                }
                 color: Colours.palette.m3onSurfaceVariant
                 font: Tokens.font.body.medium
                 wrapMode: Text.WordWrap
@@ -130,11 +141,11 @@ MouseArea {
 
                 TextButton {
                     type: ButtonBase.Filled
-                    activeColour: Colours.palette.m3error
-                    activeOnColour: Colours.palette.m3onError
-                    inactiveColour: Colours.palette.m3error
-                    inactiveOnColour: Colours.palette.m3onError
-                    text: qsTr("Delete")
+                    activeColour: root.permanent ? Colours.palette.m3error : Colours.palette.m3primary
+                    activeOnColour: root.permanent ? Colours.palette.m3onError : Colours.palette.m3onPrimary
+                    inactiveColour: root.permanent ? Colours.palette.m3error : Colours.palette.m3primary
+                    inactiveOnColour: root.permanent ? Colours.palette.m3onError : Colours.palette.m3onPrimary
+                    text: root.permanent ? qsTr("Delete") : qsTr("Move to Trash")
                     onClicked: root.accept()
                 }
             }

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -328,6 +328,14 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "delete"
+                                    text: qsTr("Confirm Move to Trash")
+                                    subtext: qsTr("Ask before moving files to the trash")
+                                    checked: AppController.confirmMoveToTrash
+                                    onToggled: checked => AppController.confirmMoveToTrash = checked
+                                }
+
+                                ToggleRow {
                                     icon: "image"
                                     text: qsTr("Show Thumbnails")
                                     subtext: qsTr("Preview images and videos instead of generic icons")

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -44,10 +44,22 @@ ApplicationWindow {
     function requestPermanentDelete(paths) {
         if (!paths || paths.length === 0) return;
         if (AppController.confirmPermanentDelete) {
+            confirmDeleteModal.permanent = true;
             confirmDeleteModal.targetPaths = paths;
             confirmDeleteModal.expanded = true;
         } else {
             FileOperations.deletePermanently(paths);
+        }
+    }
+
+    function requestMoveToTrash(paths) {
+        if (!paths || paths.length === 0) return;
+        if (AppController.confirmMoveToTrash) {
+            confirmDeleteModal.permanent = false;
+            confirmDeleteModal.targetPaths = paths;
+            confirmDeleteModal.expanded = true;
+        } else {
+            FileOperations.moveToTrash(paths);
         }
     }
 
@@ -344,7 +356,7 @@ ApplicationWindow {
                         newItemModal.expanded = true;
                     }
                 } else if (action === "trash" && item) {
-                    FileOperations.moveToTrash(targetPaths);
+                    window.requestMoveToTrash(targetPaths);
                 } else if (action === "delete" && item) {
                     window.requestPermanentDelete(targetPaths);
                 } else if (action === "newFolder") {
@@ -439,7 +451,12 @@ ApplicationWindow {
         // Permanent Delete Confirmation Modal
         ConfirmDeleteModal {
             id: confirmDeleteModal
-            onConfirmed: paths => FileOperations.deletePermanently(paths)
+            onConfirmed: paths => {
+                if (confirmDeleteModal.permanent)
+                    FileOperations.deletePermanently(paths);
+                else
+                    FileOperations.moveToTrash(paths);
+            }
         }
 
         // Places & Devices Management Modal
@@ -700,7 +717,7 @@ ApplicationWindow {
             context: Qt.ApplicationShortcut
             onActivated: {
                 let paths = splitContainer.selectedPaths.length > 0 ? splitContainer.selectedPaths : (splitContainer.currentSelectedPath ? [splitContainer.currentSelectedPath] : []);
-                if (paths.length > 0) FileOperations.moveToTrash(paths);
+                if (paths.length > 0) window.requestMoveToTrash(paths);
             }
         }
 

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -38,6 +38,7 @@ AppController::AppController(QObject* parent)
     m_showHidden = settings.value("session/showHidden", legacy1.value("session/showHidden", legacy2.value("session/showHidden", false))).toBool();
     m_singleClick = settings.value("session/singleClick", legacy1.value("session/singleClick", legacy2.value("session/singleClick", false))).toBool();
     m_confirmPermanentDelete = settings.value("session/confirmPermanentDelete", true).toBool();
+    m_confirmMoveToTrash = settings.value("session/confirmMoveToTrash", false).toBool();
     m_defaultStartupDirectory = settings.value("preferences/startupDirectory", "home").toString();
     m_defaultViewMode = settings.value("preferences/defaultViewMode", 0).toInt();
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
@@ -118,6 +119,15 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         QSettings settings("prism", "prism");
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
+    }
+}
+
+void AppController::setConfirmMoveToTrash(bool confirm) {
+    if (m_confirmMoveToTrash != confirm) {
+        m_confirmMoveToTrash = confirm;
+        QSettings settings("prism", "prism");
+        settings.setValue("session/confirmMoveToTrash", confirm);
+        emit confirmMoveToTrashChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -20,6 +20,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool confirmPermanentDelete READ confirmPermanentDelete WRITE setConfirmPermanentDelete NOTIFY confirmPermanentDeleteChanged)
+    Q_PROPERTY(bool confirmMoveToTrash READ confirmMoveToTrash WRITE setConfirmMoveToTrash NOTIFY confirmMoveToTrashChanged)
     Q_PROPERTY(int dateFormat READ dateFormat WRITE setDateFormat NOTIFY dateFormatChanged)
     Q_PROPERTY(bool thumbnailsEnabled READ thumbnailsEnabled WRITE setThumbnailsEnabled NOTIFY thumbnailsEnabledChanged)
     Q_PROPERTY(int thumbnailMaxMb READ thumbnailMaxMb WRITE setThumbnailMaxMb NOTIFY thumbnailMaxMbChanged)
@@ -73,6 +74,9 @@ public:
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
     [[nodiscard]] bool confirmPermanentDelete() const { return m_confirmPermanentDelete; }
     void setConfirmPermanentDelete(bool confirm);
+
+    [[nodiscard]] bool confirmMoveToTrash() const { return m_confirmMoveToTrash; }
+    void setConfirmMoveToTrash(bool confirm);
     [[nodiscard]] int dateFormat() const { return m_dateFormat; }
     void setDateFormat(int format);
     Q_INVOKABLE static bool shiftPressed();
@@ -156,6 +160,7 @@ signals:
     void directoryOnlyChanged();
     void showHiddenChanged();
     void confirmPermanentDeleteChanged();
+    void confirmMoveToTrashChanged();
     void dateFormatChanged();
     void thumbnailsEnabledChanged();
     void thumbnailMaxMbChanged();
@@ -187,6 +192,7 @@ private:
     bool m_directoryOnly = false;
     bool m_showHidden = false;
     bool m_confirmPermanentDelete = true;
+    bool m_confirmMoveToTrash = false;
     int m_dateFormat = 1;
     bool m_thumbnailsEnabled = true;
     int m_thumbnailMaxMb = 0;


### PR DESCRIPTION
## Problem

Prism asks before permanently deleting and offers a setting for it, but moving to the trash happens without a word and cannot be made to ask. Thunar exposes the same prompt as `misc-confirm-move-to-trash`.

## Change

`AppController.confirmMoveToTrash`, off by default as in Thunar, since trashing is reversible.

The existing `ConfirmDeleteModal` handles both rather than a second dialog appearing. It takes a `permanent` flag that picks the wording, the icon and the button colour:

- permanent: `delete_forever`, error colour, *"… will be deleted permanently. This cannot be undone."*
- trash: `delete`, primary colour, *"… will be moved to the trash."*

Reusing the error treatment for a reversible operation would train people to click past it, which is the opposite of what a confirmation is for.

Both trash call sites in `main.qml` go through a `requestMoveToTrash` helper mirroring the existing `requestPermanentDelete`.

## Also

The multi-item line in that dialog used `qsTr("%n items…", "", n)` and rendered the literal source string, the same defect as #31. It is spelled out now.
