### PR TITLE
feat: sort the trash by when items were deleted

### DIFF
--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -195,7 +195,8 @@ Item {
         deleted: {
             label: qsTr("Deletion Time"),
             width: 180,
-            sort: -1
+            sort: FileSystemModel.SortByDeleted,
+            descendingFirst: true
         }
     })
 

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -251,6 +251,7 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
                     QDateTime dt = QDateTime::fromString(dStr, Qt::ISODate);
                     if (dt.isValid()) {
                         d.deletionTime = prism::core::FileUtils::formatDateTime(dt);
+                        d.deletionDateTime = dt;
                     } else {
                         d.deletionTime = dStr;
                     }
@@ -289,6 +290,7 @@ bool FileSystemEntry::updateFromRaw(const RawEntryData& d) {
     if (m_isText != d.isText) { m_isText = d.isText; changed = true; }
     if (m_originalPath != d.originalPath) { m_originalPath = d.originalPath; changed = true; }
     if (m_deletionTime != d.deletionTime) { m_deletionTime = d.deletionTime; changed = true; }
+    if (m_deletionDateTime != d.deletionDateTime) { m_deletionDateTime = d.deletionDateTime; changed = true; }
     if (m_isTrashItem != d.isTrashItem) { m_isTrashItem = d.isTrashItem; changed = true; }
     return changed;
 }
@@ -320,6 +322,7 @@ static FileSystemEntry* createEntryFromRawData(const RawEntryData& d, QObject* p
     entry->m_isText = d.isText;
     entry->m_originalPath = d.originalPath;
     entry->m_deletionTime = d.deletionTime;
+    entry->m_deletionDateTime = d.deletionDateTime;
     entry->m_isTrashItem = d.isTrashItem;
     return entry;
 }
@@ -591,6 +594,11 @@ QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<
         case SortByType:
             res = collator.compare(a->mimeDescription(), b->mimeDescription());
             if (res == 0) res = collator.compare(a->name(), b->name());
+            break;
+        case SortByDeleted:
+            if (a->deletionDateTime() < b->deletionDateTime()) res = -1;
+            else if (a->deletionDateTime() > b->deletionDateTime()) res = 1;
+            else res = collator.compare(a->name(), b->name());
             break;
         }
 

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -38,6 +38,7 @@ struct RawEntryData {
     bool isText = false;
     QString originalPath;
     QString deletionTime;
+    QDateTime deletionDateTime;
     bool isTrashItem = false;
 };
 
@@ -101,6 +102,7 @@ public:
     bool isText() const { return m_isText; }
     QString originalPath() const { return m_originalPath; }
     QString deletionTime() const { return m_deletionTime; }
+    QDateTime deletionDateTime() const { return m_deletionDateTime; }
     bool isTrashItem() const { return m_isTrashItem; }
 
     bool updateFromRaw(const RawEntryData& d);
@@ -109,6 +111,7 @@ public:
     QString m_path;
     QString m_originalPath;
     QString m_deletionTime;
+    QDateTime m_deletionDateTime;
     bool m_isTrashItem = false;
     bool m_isDir = false;
     bool m_isSymLink = false;
@@ -154,7 +157,8 @@ public:
         SortByName,
         SortBySize,
         SortByDate,
-        SortByType
+        SortByType,
+        SortByDeleted
     };
     Q_ENUM(SortField)
 


### PR DESCRIPTION
## Problem

The trash view has a Deletion Time column and no way to sort by it. `SortField` stops at name, size, type and modification date, so the column header is inert. Thunar has `sort-by-dtime` for exactly this.

Sorting the trash by name is rarely what you want. Sorting it by when things went in is almost always what you want.

## Change

`SortByDeleted`, and the column declares it.

The interesting part is that the entry only kept `deletionTime` as an already formatted string. Sorting on that compares text, so a locale format orders by weekday name — Dienstag before Mittwoch before Montag. The parsed `QDateTime` is now kept alongside the formatted string and the comparator uses it.

Since the details view became data-driven, the column itself is one line: `sort: FileSystemModel.SortByDeleted` with `descendingFirst`, so the first click shows the most recently deleted.

## Verified

Against a trash holding 16 items across three days. Sorted descending the order is 23 August, then 22, then 19, correctly grouped under the folders-first setting that puts directories in their own block.
