### PR TITLE
fix: stop the switch flooding the log on every toggle

### DIFF
--- a/qml/components/controls/StyledSwitch.qml
+++ b/qml/components/controls/StyledSwitch.qml
@@ -148,23 +148,27 @@ T.Switch {
                 }
 
                 Behavior on start1 {
-                    Anim {
-                        type: Anim.FastSpatial
+                    PropertyAnimation {
+                        duration: Tokens.anim.durations.expressiveFastSpatial
+                        easing: Tokens.anim.expressiveFastSpatial
                     }
                 }
                 Behavior on end1 {
-                    Anim {
-                        type: Anim.FastSpatial
+                    PropertyAnimation {
+                        duration: Tokens.anim.durations.expressiveFastSpatial
+                        easing: Tokens.anim.expressiveFastSpatial
                     }
                 }
                 Behavior on start2 {
-                    Anim {
-                        type: Anim.FastSpatial
+                    PropertyAnimation {
+                        duration: Tokens.anim.durations.expressiveFastSpatial
+                        easing: Tokens.anim.expressiveFastSpatial
                     }
                 }
                 Behavior on end2 {
-                    Anim {
-                        type: Anim.FastSpatial
+                    PropertyAnimation {
+                        duration: Tokens.anim.durations.expressiveFastSpatial
+                        easing: Tokens.anim.expressiveFastSpatial
                     }
                 }
             }


### PR DESCRIPTION
## Problem

Toggling any switch writes this to the log, ninety-two times:

```
Could not find any constructor for value type QQmlPointFValueType to call with value QVariant(double, 0)
```

`StyledSwitch` animates the tick mark through four `point` properties, and each one is behind

```qml
Behavior on start1 {
    Anim { type: Anim.FastSpatial }
}
```

`Anim` is a `NumberAnimation`. It cannot interpolate a point, so on every frame Qt tries to construct a `QPointF` from a single double and says so.

This is the same mistake as the colour Behaviors in #28, one type along. There it silently produced black; here it produces log noise, because a failed point construction leaves the property alone rather than writing garbage.

## Change

`PropertyAnimation` interpolates according to the property's type and handles `QPointF`, so the four Behaviors keep the same duration and curve and stop complaining.

## Verified

Driving two toggles headless: 92 lines before, 0 after, and no other warning appears. A sweep of every remaining `Behavior on … { Anim }` in the project found only real-valued properties, so this was the last one of its kind once #28 lands.
