### PR TITLE
feat: create a document from a template

### DIFF
--- a/qml/components/dialogs/NewItemModal.qml
+++ b/qml/components/dialogs/NewItemModal.qml
@@ -12,6 +12,7 @@ MouseArea {
     property string icon: "note_add"
     property string initialText: ""
     property string targetRenamePath: ""
+    property string templateSource: ""
 
     signal accepted(string text)
 
@@ -47,6 +48,7 @@ MouseArea {
         } else {
             input.focus = false;
             targetRenamePath = "";
+            templateSource = "";
             if (typeof splitContainer !== "undefined" && splitContainer) {
                 splitContainer.focusActiveView();
             }

--- a/qml/components/menus/ContextMenu.qml
+++ b/qml/components/menus/ContextMenu.qml
@@ -253,6 +253,20 @@ MouseArea {
                             { text: qsTr("New Text File"), icon: "note_add", action: "newFile" }
                         ];
 
+                        const templates = FileUtils.templates();
+                        if (templates.length > 0) {
+                            blankList.push({
+                                text: qsTr("New from Template"),
+                                icon: "file_copy",
+                                hasSubmenu: true,
+                                submenuItems: templates.map(t => ({
+                                    text: t.name,
+                                    icon: t.icon,
+                                    action: "newFromTemplate:" + t.path
+                                }))
+                            });
+                        }
+
                         if (FileOperations.canPaste) {
                             blankList.push({ text: qsTr("Paste"), icon: "content_paste", action: "paste" });
                             if (AppController.menuShowSymlink) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -387,6 +387,13 @@ ApplicationWindow {
                         operationsModal.expanded = true;
                         FileOperations.uploadToLitterbox(pathsToUpload, time);
                     }
+                } else if (action.startsWith("newFromTemplate:")) {
+                    const templatePath = action.substring(16);
+                    newItemModal.title = qsTr("New from Template");
+                    newItemModal.icon = "file_copy";
+                    newItemModal.templateSource = templatePath;
+                    newItemModal.initialText = templatePath.split("/").pop();
+                    newItemModal.expanded = true;
                 } else if (action === "newFile") {
                     newItemModal.title = qsTr("Create New File");
                     newItemModal.icon = "note_add";
@@ -480,6 +487,8 @@ ApplicationWindow {
                     FileOperations.createDirectory(currentDir, text);
                 } else if (title === qsTr("Create New File")) {
                     FileOperations.createFile(currentDir, text);
+                } else if (title === qsTr("New from Template")) {
+                    FileOperations.createFromTemplate(newItemModal.templateSource, currentDir, text);
                 } else if (title === qsTr("Rename")) {
                     let oldPath = newItemModal.targetRenamePath || (contextMenu.targetItem ? contextMenu.targetItem.path : "");
                     if (oldPath) {

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -710,6 +710,43 @@ void FileOperations::bulkRename(const QStringList& paths, const QStringList& new
     emit operationFinished(true, tr("Renamed %n item(s)", "", static_cast<int>(sources.size())));
 }
 
+void FileOperations::createFromTemplate(const QString& templatePath, const QString& parentDir, const QString& name) {
+    const QString trimmed = name.trimmed();
+    if (templatePath.isEmpty() || parentDir.isEmpty() || trimmed.isEmpty() || trimmed.contains(QLatin1Char('/'))) {
+        emit operationFinished(false, tr("Invalid name"));
+        return;
+    }
+
+    if (!QFileInfo::exists(templatePath)) {
+        emit operationFinished(false, tr("Template no longer exists"));
+        return;
+    }
+
+    const QString destination = parentDir + QLatin1Char('/') + trimmed;
+    if (QFileInfo::exists(destination)) {
+        emit operationFinished(false, tr("%1 already exists").arg(trimmed));
+        return;
+    }
+
+    if (!QFile::copy(templatePath, destination)) {
+        emit operationFinished(false, tr("Could not create %1").arg(trimmed));
+        return;
+    }
+
+    QFile::setPermissions(destination, QFile::permissions(destination) | QFile::WriteOwner);
+
+    UndoAction action;
+    action.type = UndoAction::CreateFile;
+    action.newPath = destination;
+    action.parentDir = parentDir;
+    action.name = trimmed;
+    m_undoStack.push_back(action);
+    m_redoStack.clear();
+    emit undoStackChanged();
+
+    emit operationFinished(true, tr("Created %1").arg(trimmed));
+}
+
 void FileOperations::createDirectory(const QString& parentDir, const QString& name) {
     QDir dir(parentDir);
     bool success = dir.mkdir(name);

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -126,6 +126,7 @@ public:
     Q_INVOKABLE void bulkRename(const QStringList& paths, const QStringList& newNames);
     Q_INVOKABLE void createDirectory(const QString& parentDir, const QString& name);
     Q_INVOKABLE void createFile(const QString& parentDir, const QString& name, const QString& content = "");
+    Q_INVOKABLE void createFromTemplate(const QString& templatePath, const QString& parentDir, const QString& name);
     Q_INVOKABLE void duplicateFile(const QString& path);
     Q_INVOKABLE void createSymlink(const QString& target, const QString& linkPath);
     Q_INVOKABLE void pasteAsSymlink(const QString& destinationDir);

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -152,7 +152,24 @@ QVariantList FileUtils::templates() {
         QVariantMap entry;
         entry.insert(QStringLiteral("name"), fi.fileName());
         entry.insert(QStringLiteral("path"), fi.absoluteFilePath());
-        entry.insert(QStringLiteral("icon"), iconForFile(fi.fileName(), false, mimeTypeForFile(fi.absoluteFilePath())));
+        const QString mime = mimeTypeForFile(fi.absoluteFilePath());
+        QString glyph = QStringLiteral("description");
+        if (mime.startsWith(QLatin1String("image/")))
+            glyph = QStringLiteral("image");
+        else if (mime.startsWith(QLatin1String("audio/")))
+            glyph = QStringLiteral("music_note");
+        else if (mime.startsWith(QLatin1String("video/")))
+            glyph = QStringLiteral("movie");
+        else if (mime.contains(QLatin1String("shellscript")) || mime.contains(QLatin1String("executable")))
+            glyph = QStringLiteral("terminal");
+        else if (mime.contains(QLatin1String("spreadsheet")) || mime.contains(QLatin1String("csv")))
+            glyph = QStringLiteral("table");
+        else if (mime.contains(QLatin1String("presentation")))
+            glyph = QStringLiteral("slideshow");
+        else if (mime.contains(QLatin1String("pdf")))
+            glyph = QStringLiteral("picture_as_pdf");
+
+        entry.insert(QStringLiteral("icon"), glyph);
         entries.append(entry);
     }
 

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -137,6 +137,28 @@ QVariantList FileUtils::describePaths(const QStringList& paths) {
     return entries;
 }
 
+QVariantList FileUtils::templates() {
+    QVariantList entries;
+
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::TemplatesLocation);
+    if (dir.isEmpty() || !QDir(dir).exists())
+        return entries;
+
+    const QFileInfoList files = QDir(dir).entryInfoList(QDir::Files | QDir::NoDotAndDotDot, QDir::Name);
+    for (const QFileInfo& fi : files) {
+        if (entries.size() >= 50)
+            break;
+
+        QVariantMap entry;
+        entry.insert(QStringLiteral("name"), fi.fileName());
+        entry.insert(QStringLiteral("path"), fi.absoluteFilePath());
+        entry.insert(QStringLiteral("icon"), iconForFile(fi.fileName(), false, mimeTypeForFile(fi.absoluteFilePath())));
+        entries.append(entry);
+    }
+
+    return entries;
+}
+
 bool FileUtils::isImage(const QString& path) {
     if (path.isEmpty()) return false;
     static const QMimeDatabase db;

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -50,6 +50,7 @@ public:
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
     Q_INVOKABLE static QString baseName(const QString& path);
     Q_INVOKABLE static QVariantList describePaths(const QStringList& paths);
+    Q_INVOKABLE static QVariantList templates();
     Q_INVOKABLE static bool isImage(const QString& path);
     Q_INVOKABLE static bool isVideo(const QString& path);
     Q_INVOKABLE static bool isAudio(const QString& path);


### PR DESCRIPTION
## Problem

The only way to start a file in Prism is New Text File, which makes an empty one. Thunar lists the XDG templates directory as a Create Document submenu.

## Change

`FileUtils.templates()` reads `QStandardPaths::TemplatesLocation` — `~/Templates`, or whatever the locale calls it; on a German system it resolves to `~/Vorlagen`, which is why hardcoding the English name would not have worked. Each entry carries its mime icon so the submenu looks like the rest of the menus.

Picking one opens the existing new-item dialog prefilled with the template's file name. Naming before writing rather than creating `Untitled` and renaming afterwards matches how New Folder already behaves here.

`FileOperations::createFromTemplate` copies, refuses an existing name rather than overwriting, and pushes the same undo entry as creating a file, so Ctrl+Z removes it.

**The copy is made writable by its owner.** `QFile::copy` carries the source mode across, and a template kept read-only — which is a reasonable thing to do to a template — would otherwise produce a file you cannot edit.

## Scope

The top level of the directory only, capped at 50 entries. Thunar walks subdirectories into nested submenus and caps with `misc-max-number-of-templates`; nesting can follow if anyone keeps templates that way.

## Verified

Three templates in `~/Vorlagen` are listed by name. Creating from an empty one gives an empty file; from a two-line script gives the same two lines and 28 bytes at mode 644. A second create under the same name leaves the first alone.
