### PR TITLE
fix: make the save dialog a save dialog

### DIFF
--- a/qml/components/filedialog/DialogButtons.qml
+++ b/qml/components/filedialog/DialogButtons.qml
@@ -12,6 +12,15 @@ StyledRect {
 
     property bool uploadingFromDialog: false
 
+    function commitSave() {
+        if (!root.dialog.saveMode)
+            return;
+        const name = root.dialog.saveName.trim();
+        if (name.length === 0 || name.indexOf("/") >= 0)
+            return;
+        root.dialog.accepted(root.dialog.savePath);
+    }
+
     Connections {
         target: CatboxUploader
         function onUploadFinished(success, result, path) {
@@ -30,12 +39,56 @@ StyledRect {
 
     color: Colours.tPalette.m3surfaceContainer
 
-    RowLayout {
+    ColumnLayout {
         id: inner
 
         anchors.fill: parent
         anchors.margins: Tokens.padding.medium
 
+        spacing: Tokens.spacing.small
+
+        RowLayout {
+            Layout.fillWidth: true
+            visible: root.dialog.saveMode
+            spacing: Tokens.spacing.small
+
+            StyledText {
+                text: qsTr("Name:")
+            }
+
+            StyledRect {
+                Layout.fillWidth: true
+                implicitHeight: 34
+                radius: Tokens.rounding.medium
+                color: Colours.tPalette.m3surfaceContainerHigh
+                border.color: saveNameInput.activeFocus ? Colours.palette.m3primary : "transparent"
+                border.width: saveNameInput.activeFocus ? 2 : 0
+
+                TextInput {
+                    id: saveNameInput
+                    anchors.fill: parent
+                    anchors.margins: Tokens.padding.small
+                    verticalAlignment: TextInput.AlignVCenter
+                    text: root.dialog.saveName
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.body.medium
+                    selectByMouse: true
+                    clip: true
+                    onTextChanged: root.dialog.saveName = text
+                    onAccepted: root.commitSave()
+                }
+            }
+
+            StyledText {
+                visible: root.dialog.saveWouldOverwrite
+                text: qsTr("already exists")
+                color: Colours.palette.m3error
+                font: Tokens.font.label.medium
+            }
+        }
+
+        RowLayout {
+        Layout.fillWidth: true
         spacing: Tokens.spacing.small
 
         StyledText {
@@ -214,9 +267,13 @@ StyledRect {
             implicitHeight: selectText.implicitHeight + Tokens.padding.medium * 2
 
             StateLayer {
-                disabled: !root.dialog.selectionValid || CatboxUploader.isUploading
+                disabled: root.dialog.saveMode
+                    ? (root.dialog.saveName.trim().length === 0 || CatboxUploader.isUploading)
+                    : (!root.dialog.selectionValid || CatboxUploader.isUploading)
                 onClicked: {
-                    if (root.dialog.selectionValid && !CatboxUploader.isUploading) {
+                    if (root.dialog.saveMode) {
+                        root.commitSave();
+                    } else if (root.dialog.selectionValid && !CatboxUploader.isUploading) {
                         if (root.dialog.directoryOnly) {
                             if (root.folder && root.folder.currentItem && root.folder.currentItem.modelData && root.folder.currentItem.modelData.isDir) {
                                 root.dialog.accepted(root.folder.currentItem.modelData.path);
@@ -236,8 +293,19 @@ StyledRect {
                 anchors.centerIn: parent
                 anchors.margins: Tokens.padding.medium
 
-                text: root.dialog.directoryOnly ? qsTr("Select Folder") : qsTr("Select")
-                color: root.dialog.selectionValid && !CatboxUploader.isUploading ? Colours.palette.m3onSurface : Colours.palette.m3outline
+                text: root.dialog.saveMode
+                    ? (root.dialog.saveWouldOverwrite ? qsTr("Overwrite") : qsTr("Save"))
+                    : (root.dialog.directoryOnly ? qsTr("Select Folder") : qsTr("Select"))
+                color: {
+                    if (root.dialog.saveMode) {
+                        if (root.dialog.saveName.trim().length === 0)
+                            return Colours.palette.m3outline;
+                        return root.dialog.saveWouldOverwrite ? Colours.palette.m3error : Colours.palette.m3onSurface;
+                    }
+                    return root.dialog.selectionValid && !CatboxUploader.isUploading
+                        ? Colours.palette.m3onSurface
+                        : Colours.palette.m3outline;
+                }
             }
         }
 
@@ -266,6 +334,7 @@ StyledRect {
 
                 text: qsTr("Cancel")
             }
+        }
         }
     }
 }

--- a/qml/components/filedialog/FileDialog.qml
+++ b/qml/components/filedialog/FileDialog.qml
@@ -14,6 +14,10 @@ StyledRect {
     property string title: AppController.title || qsTr("Select a file")
     property bool showHidden: AppController.showHidden
     property bool directoryOnly: AppController.directoryOnly
+    readonly property bool saveMode: AppController.saveMode
+    property string saveName: AppController.suggestedName
+    readonly property string savePath: currentPath === "/" ? "/" + saveName : currentPath + "/" + saveName
+    readonly property bool saveWouldOverwrite: saveMode && saveName.length > 0 && AppController.fileExists(savePath)
     property real zoomLevel: 80
 
     signal accepted(string path)

--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -309,6 +309,8 @@ Item {
             let newCwd = root.dialog.cwd.slice();
             newCwd.push(file.name);
             root.dialog.cwd = newCwd;
+        } else if (root.dialog.saveMode) {
+            root.dialog.saveName = file.name;
         } else if (root.dialog.selectionValid && !root.dialog.directoryOnly) {
             root.dialog.accepted(file.path);
         }

--- a/src/config/tokens.hpp
+++ b/src/config/tokens.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include "font.hpp"
 #include <QObject>
 #include <QEasingCurve>
@@ -265,7 +268,6 @@ class TokensSingleton : public QObject {
     Q_PROPERTY(prism::config::SizeTokens* sizes READ sizes CONSTANT)
 
 public:
-    explicit TokensSingleton(QObject* parent = nullptr);
 
     RoundingTokens* rounding() const { return m_rounding; }
     SpacingTokens* spacing() const { return m_spacing; }
@@ -279,8 +281,12 @@ public:
     void reload();
 
     static TokensSingleton* instance();
+    static TokensSingleton* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
 private:
+    explicit TokensSingleton(QObject* parent = nullptr);
     RoundingTokens* m_rounding = nullptr;
     SpacingTokens* m_spacing = nullptr;
     PaddingTokens* m_padding = nullptr;

--- a/src/controllers/tabmanager.hpp
+++ b/src/controllers/tabmanager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QAbstractListModel>
 #include <QObject>
 #include <QString>
@@ -92,9 +95,11 @@ public:
     };
     Q_ENUM(TabRoles)
 
-    explicit TabManager(QObject* parent = nullptr);
 
     static TabManager* instance();
+    static TabManager* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
@@ -120,6 +125,7 @@ signals:
     void countChanged();
 
 private:
+    explicit TabManager(QObject* parent = nullptr);
     QVector<TabItem*> m_tabs;
     int m_currentIndex = 0;
 };

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -5,6 +5,7 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 #include "iconprovider.hpp"
+#include <QFileInfo>
 #include <QSettings>
 #include <iostream>
 
@@ -307,6 +308,24 @@ void AppController::setPlacesIconSize(int size) {
         settings.setValue("preferences/placesIconSize", size);
         emit placesIconSizeChanged();
     }
+}
+
+void AppController::setSaveMode(bool save) {
+    if (m_saveMode != save) {
+        m_saveMode = save;
+        emit saveModeChanged();
+    }
+}
+
+void AppController::setSuggestedName(const QString& name) {
+    if (m_suggestedName != name) {
+        m_suggestedName = name;
+        emit suggestedNameChanged();
+    }
+}
+
+bool AppController::fileExists(const QString& path) {
+    return QFileInfo::exists(path);
 }
 
 void AppController::accept(const QString& path) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QVariantMap>
 #include <QString>
@@ -48,9 +51,11 @@ class AppController : public QObject {
     Q_PROPERTY(bool showNetworkSection READ showNetworkSection WRITE setShowNetworkSection NOTIFY showNetworkSectionChanged)
 
 public:
-    explicit AppController(QObject* parent = nullptr);
 
     static AppController* instance();
+    static AppController* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] int iconThemeVersion() const { return m_iconThemeVersion; }
     Q_INVOKABLE void triggerIconReload();
@@ -180,6 +185,7 @@ signals:
     void rejected();
 
 private:
+    explicit AppController(QObject* parent = nullptr);
     QString m_title = "Select a file";
     QString m_initialDirectory;
     QString m_filterLabel = "All files";

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -21,6 +21,8 @@ class AppController : public QObject {
     Q_PROPERTY(QString initialDirectory READ initialDirectory WRITE setInitialDirectory NOTIFY initialDirectoryChanged)
     Q_PROPERTY(QString filterLabel READ filterLabel WRITE setFilterLabel NOTIFY filterLabelChanged)
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
+    Q_PROPERTY(bool saveMode READ saveMode NOTIFY saveModeChanged)
+    Q_PROPERTY(QString suggestedName READ suggestedName NOTIFY suggestedNameChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool confirmPermanentDelete READ confirmPermanentDelete WRITE setConfirmPermanentDelete NOTIFY confirmPermanentDeleteChanged)
     Q_PROPERTY(int dateFormat READ dateFormat WRITE setDateFormat NOTIFY dateFormatChanged)
@@ -74,6 +76,12 @@ public:
 
     [[nodiscard]] bool directoryOnly() const { return m_directoryOnly; }
     void setDirectoryOnly(bool dirOnly);
+
+    [[nodiscard]] bool saveMode() const { return m_saveMode; }
+    void setSaveMode(bool save);
+    [[nodiscard]] QString suggestedName() const { return m_suggestedName; }
+    void setSuggestedName(const QString& name);
+    Q_INVOKABLE static bool fileExists(const QString& path);
 
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
     [[nodiscard]] bool confirmPermanentDelete() const { return m_confirmPermanentDelete; }
@@ -159,6 +167,8 @@ signals:
     void filterLabelChanged();
     void filtersChanged();
     void directoryOnlyChanged();
+    void saveModeChanged();
+    void suggestedNameChanged();
     void showHiddenChanged();
     void confirmPermanentDeleteChanged();
     void dateFormatChanged();
@@ -191,6 +201,8 @@ private:
     QString m_filterLabel = "All files";
     QStringList m_filters = { "*" };
     bool m_directoryOnly = false;
+    bool m_saveMode = false;
+    QString m_suggestedName;
     bool m_showHidden = false;
     bool m_confirmPermanentDelete = true;
     int m_dateFormat = 1;

--- a/src/core/appintegration.hpp
+++ b/src/core/appintegration.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QVariantList>
@@ -14,9 +17,11 @@ class AppIntegration : public QObject {
     QML_SINGLETON
 
 public:
-    explicit AppIntegration(QObject* parent = nullptr);
 
     static AppIntegration* instance();
+    static AppIntegration* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     Q_INVOKABLE QVariantList getAppsForFile(const QString& filePath);
     Q_INVOKABLE QVariantList getAvailableSharingServices();
@@ -42,6 +47,7 @@ public:
 
 
 private:
+    explicit AppIntegration(QObject* parent = nullptr);
     void scanDesktopFiles();
     void scanCustomActions();
 

--- a/src/core/catboxuploader.hpp
+++ b/src/core/catboxuploader.hpp
@@ -37,7 +37,6 @@ public:
         QString time = QStringLiteral("24h");
     };
 
-    explicit CatboxUploader(QObject* parent = nullptr);
     ~CatboxUploader() override;
 
     static CatboxUploader* instance();
@@ -72,6 +71,7 @@ private slots:
     void onReplyFinished();
 
 private:
+    explicit CatboxUploader(QObject* parent = nullptr);
     void enqueue(const QStringList& filePaths, Service service, const QString& time);
     void clearSharedProgress(const QString& finalStatusText = QString());
     static QString serviceDisplayName(Service service, const QString& time);

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -61,7 +61,6 @@ class FileOperations : public QObject {
     Q_PROPERTY(QVariantList completedTasks READ completedTasks NOTIFY completedTasksChanged)
 
 public:
-    explicit FileOperations(QObject* parent = nullptr);
 
     static FileOperations* instance();
     static FileOperations* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
@@ -143,6 +142,8 @@ signals:
     void conflictOccurred(const QString& source, const QString& destination);
 
 private:
+    explicit FileOperations(QObject* parent = nullptr);
+
     struct UndoAction {
         enum Type {
             Rename,

--- a/src/core/gitmanager.hpp
+++ b/src/core/gitmanager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -22,8 +25,10 @@ class GitManager : public QObject {
     Q_PROPERTY(QString lastStatusMessage READ lastStatusMessage NOTIFY statusMessageChanged)
 
 public:
-    explicit GitManager(QObject* parent = nullptr);
     static GitManager* instance();
+    static GitManager* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     QString currentPath() const { return m_currentPath; }
     void setCurrentPath(const QString& path);
@@ -47,6 +52,7 @@ signals:
     void statusMessageChanged();
 
 private:
+    explicit GitManager(QObject* parent = nullptr);
     QString findGitRoot(const QString& startPath) const;
 
     QString m_currentPath;

--- a/src/core/iconcatalog.hpp
+++ b/src/core/iconcatalog.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -15,8 +18,10 @@ class IconCatalog : public QObject {
     Q_PROPERTY(int totalIcons READ totalIcons CONSTANT)
 
 public:
-    explicit IconCatalog(QObject* parent = nullptr);
     static IconCatalog* instance();
+    static IconCatalog* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     int totalIcons() const { return m_icons.size(); }
 
@@ -24,6 +29,7 @@ public:
     Q_INVOKABLE QStringList getAllIcons() const { return m_icons; }
 
 private:
+    explicit IconCatalog(QObject* parent = nullptr);
     void loadIcons();
     QStringList m_icons;
 };

--- a/src/core/mimeservice.hpp
+++ b/src/core/mimeservice.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QString>
 #include <QVariantList>
@@ -14,8 +17,10 @@ class MimeService : public QObject {
     QML_SINGLETON
 
 public:
-    explicit MimeService(QObject* parent = nullptr);
     static MimeService* instance();
+    static MimeService* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     Q_INVOKABLE QVariantList getApplicationsForFile(const QString& filePath);
     Q_INVOKABLE QVariantList getAllApplications();
@@ -23,6 +28,10 @@ public:
     Q_INVOKABLE QVariantMap getDefaultAppForFile(const QString& filePath);
     Q_INVOKABLE void openWith(const QString& filePath, const QString& desktopFilePath);
     Q_INVOKABLE void setDefaultApp(const QString& mimeType, const QString& desktopFileName);
+
+private:
+    explicit MimeService(QObject* parent = nullptr);
+
 };
 
 } // namespace prism::core

--- a/src/core/networkmanager.hpp
+++ b/src/core/networkmanager.hpp
@@ -21,7 +21,6 @@ class NetworkManager : public QObject {
     Q_PROPERTY(QStringList supportedSchemes READ supportedSchemes CONSTANT)
 
 public:
-    explicit NetworkManager(QObject* parent = nullptr);
     ~NetworkManager() override = default;
 
     static NetworkManager* instance();
@@ -50,6 +49,7 @@ signals:
     void unmounted(const QString& path);
 
 private:
+    explicit NetworkManager(QObject* parent = nullptr);
     void handleMountProcessFinished(int exitCode, QProcess::ExitStatus exitStatus, const QString& uri, bool saveBookmark);
     QString resolveGvfsPath(const QString& uri) const;
 

--- a/src/core/papiruswatcher.hpp
+++ b/src/core/papiruswatcher.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QFileSystemWatcher>
 #include <QObject>
 #include <QStringList>
@@ -18,10 +21,12 @@ class PapirusWatcher : public QObject {
     Q_PROPERTY(bool isAvailable READ isAvailable CONSTANT)
 
 public:
-    explicit PapirusWatcher(QObject* parent = nullptr);
     ~PapirusWatcher() override = default;
 
     static PapirusWatcher* instance();
+    static PapirusWatcher* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] QString currentColor() const;
     [[nodiscard]] QStringList availableColors() const;
@@ -38,6 +43,7 @@ private slots:
     void onDebounceTimeout();
 
 private:
+    explicit PapirusWatcher(QObject* parent = nullptr);
     void scanAndWatch();
     void addPathIfValid(const QString& path, bool isDir);
     QString readColorFromKeepFile(const QString& filePath) const;

--- a/src/core/placesmodel.hpp
+++ b/src/core/placesmodel.hpp
@@ -46,7 +46,6 @@ public:
     };
     Q_ENUM(PlaceRoles)
 
-    explicit PlacesModel(QObject* parent = nullptr);
     ~PlacesModel() override = default;
 
     static PlacesModel* instance();
@@ -85,6 +84,7 @@ signals:
     void countChanged();
 
 private:
+    explicit PlacesModel(QObject* parent = nullptr);
     void loadHiddenPlaces();
     void saveHiddenPlaces();
     void loadStandardPlaces();

--- a/src/core/runnergame.hpp
+++ b/src/core/runnergame.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QQmlEngine>
+#include <QJSEngine>
+
 #include <QObject>
 #include <QVariantList>
 #include <QVariantMap>
@@ -75,10 +78,12 @@ public:
     };
     Q_ENUM(ObstacleType)
 
-    explicit RunnerGame(QObject* parent = nullptr);
     ~RunnerGame() override = default;
 
     static RunnerGame* instance();
+    static RunnerGame* create(QQmlEngine* = nullptr, QJSEngine* = nullptr) {
+        return instance();
+    }
 
     [[nodiscard]] int state() const { return m_state; }
     [[nodiscard]] int score() const { return m_score; }
@@ -125,6 +130,7 @@ private slots:
     void gameLoop();
 
 private:
+    explicit RunnerGame(QObject* parent = nullptr);
     void updatePhysics(qreal framesElapsed, qreal dt);
     void updateObstacles(qreal framesElapsed, qreal dt);
     void updateClouds(qreal framesElapsed, qreal dt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[]) {
 
     auto* appIntegration = prism::core::AppIntegration::instance();
     auto* papirusWatcher = prism::core::PapirusWatcher::instance();
-    auto* placesModel = new prism::core::PlacesModel(&app);
+    auto* placesModel = prism::core::PlacesModel::instance();
     auto* driveManager = new prism::core::DriveManager(&app);
     auto* networkManager = prism::core::NetworkManager::instance();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,8 @@ int main(int argc, char* argv[]) {
     QCommandLineOption filterOption(QStringList{ "f", "filter" }, "File extensions filter, e.g. 'png,jpg' or '*.png,*.jpg'", "filter");
     QCommandLineOption filterLabelOption(QStringList{ "l", "filter-label" }, "Filter label, e.g. 'Images'", "label");
     QCommandLineOption dirOnlyOption(QStringList{ "directory-only" }, "Select directories only");
+    QCommandLineOption saveOption(QStringList{ "save" }, "Pick a destination for saving rather than an existing file");
+    QCommandLineOption nameOption(QStringList{ "name" }, "Suggested file name when saving", "name");
     QCommandLineOption hiddenOption(QStringList{ "hidden" }, "Show hidden files by default");
     QCommandLineOption lightOption(QStringList{ "light" }, "Force light theme");
     QCommandLineOption darkOption(QStringList{ "dark" }, "Force dark theme");
@@ -73,6 +75,8 @@ int main(int argc, char* argv[]) {
     parser.addOption(filterOption);
     parser.addOption(filterLabelOption);
     parser.addOption(dirOnlyOption);
+    parser.addOption(saveOption);
+    parser.addOption(nameOption);
     parser.addOption(hiddenOption);
     parser.addOption(lightOption);
     parser.addOption(darkOption);
@@ -103,7 +107,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    bool isPickerMode = parser.isSet(pickerOption) || parser.isSet(filterOption) || parser.isSet(dirOnlyOption);
+    bool isPickerMode = parser.isSet(pickerOption) || parser.isSet(filterOption) || parser.isSet(dirOnlyOption) || parser.isSet(saveOption);
 
     auto* controller = prism::core::AppController::instance();
     controller->setTitle(parser.isSet(titleOption) ? parser.value(titleOption) : QStringLiteral("Select a file"));
@@ -129,6 +133,9 @@ int main(int argc, char* argv[]) {
         controller->setFilters(filters);
     }
     controller->setDirectoryOnly(parser.isSet(dirOnlyOption));
+    controller->setSaveMode(parser.isSet(saveOption));
+    if (parser.isSet(nameOption))
+        controller->setSuggestedName(parser.value(nameOption));
     if (parser.isSet(hiddenOption)) {
         controller->setShowHidden(true);
     }

--- a/src/portal/filechooserportal.cpp
+++ b/src/portal/filechooserportal.cpp
@@ -209,7 +209,22 @@ void FileChooserPortal::SaveFile(const QDBusObjectPath& handle,
         filterLabel = options.value("accept_label").toString();
     }
 
-    launchPrismPicker(dialogTitle, initialDir, false, filters, filterLabel, handle, message);
+    QString suggestedName;
+    if (options.contains(QStringLiteral("current_name")))
+        suggestedName = options.value(QStringLiteral("current_name")).toString();
+
+    if (options.contains(QStringLiteral("current_file"))) {
+        const QString current = QFile::decodeName(options.value(QStringLiteral("current_file")).toByteArray());
+        const QFileInfo info(current.trimmed());
+        if (!info.filePath().isEmpty()) {
+            if (suggestedName.isEmpty())
+                suggestedName = info.fileName();
+            if (initialDir.isEmpty())
+                initialDir = info.absolutePath();
+        }
+    }
+
+    launchPrismPicker(dialogTitle, initialDir, false, filters, filterLabel, handle, message, false, {}, true, suggestedName);
 }
 
 void FileChooserPortal::SaveFiles(const QDBusObjectPath& handle,
@@ -255,7 +270,9 @@ void FileChooserPortal::launchPrismPicker(const QString& title,
                                          const QDBusObjectPath& handle,
                                          const QDBusMessage& message,
                                          bool isSaveFiles,
-                                         const QStringList& fileList) {
+                                         const QStringList& fileList,
+                                         bool saveMode,
+                                         const QString& suggestedName) {
     QString handleStr = handle.path();
     auto* process = new QProcess(this);
     auto* reqObj = new PortalRequest(handleStr, this);
@@ -287,6 +304,11 @@ void FileChooserPortal::launchPrismPicker(const QString& title,
     }
     if (!filterLabel.isEmpty()) {
         args << QStringLiteral("-l") << filterLabel;
+    }
+    if (saveMode) {
+        args << QStringLiteral("--save");
+        if (!suggestedName.isEmpty())
+            args << QStringLiteral("--name") << suggestedName;
     }
 
     connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,

--- a/src/portal/filechooserportal.hpp
+++ b/src/portal/filechooserportal.hpp
@@ -77,7 +77,9 @@ private:
                            const QDBusObjectPath& handle,
                            const QDBusMessage& message,
                            bool isSaveFiles = false,
-                           const QStringList& fileList = {});
+                           const QStringList& fileList = {},
+                           bool saveMode = false,
+                           const QString& suggestedName = {});
 
     static QString findPrismBinary();
     static QString parseInitialDirectory(const QVariantMap& options);


### PR DESCRIPTION
## Problem

Reported: the save dialog looks exactly like the open dialog, so a file cannot be saved without overwriting an existing one.

That is precisely what the code does. `FileChooserPortal::SaveFile` builds the same arguments as `OpenFile` and calls the same picker:

```cpp
launchPrismPicker(dialogTitle, initialDir, false, filters, filterLabel, handle, message);
```

There is no save mode anywhere in the picker. The only value it can return is the path of a file that already exists, which the calling application then writes over. `current_name` and `current_file` from the portal options, which carry the suggested file name, are read by nobody.

## Change

A save mode carried from the portal through to the picker as `--save` and `--name`, with `current_file` used for the suggested name and starting directory when `current_name` and `current_folder` are absent.

In that mode the dialog grows a name field above the buttons, the accept button reads Save and returns the current directory joined with the typed name, and clicking a file in the list fills the field instead of accepting straight away — which is what made the reported overwrite so easy.

**An existing name is allowed but shown.** Replacing a file is a legitimate save, so it is not blocked; the field is marked `already exists` and the button changes to Overwrite in the error colour. Refusing it outright would break saving over a file on purpose, which is common.

## Depends on #27

This cannot work without it, and the reason is worth stating on its own: **the picker currently ignores every option the portal passes.** `main.cpp` applies title, filters, directory and the rest to `AppController::instance()`, while the QML picker reads the separate instance the engine constructs. Measured on main, `--save` parses correctly and `setSaveMode(true)` runs, and QML still reads `false`. The same is true of `-d`: the dialog opens in the home directory no matter what the portal asked for.

So the save dialog is the visible half of this. The invisible half is that the open dialog has been ignoring its title, filters and starting directory too.

## Verified

With #27 in place and the picker started as `--save --name bericht.pdf -d ~/prism-test`: save mode reaches QML, the name is prefilled, the composed path is `~/prism-test/bericht.pdf`, the overwrite flag follows the typed name reactively, and accepting prints the composed destination to stdout, which is what the portal turns into the returned URI.
