### PR TITLE
feat: restore the open tabs on startup

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -328,6 +328,14 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "tab_duplicate"
+                                    text: qsTr("Restore Tabs on Startup")
+                                    subtext: qsTr("Reopen the tabs that were open when the window was last closed")
+                                    checked: AppController.restoreTabs
+                                    onToggled: checked => AppController.restoreTabs = checked
+                                }
+
+                                ToggleRow {
                                     icon: "image"
                                     text: qsTr("Show Thumbnails")
                                     subtext: qsTr("Preview images and videos instead of generic icons")

--- a/src/controllers/tabmanager.cpp
+++ b/src/controllers/tabmanager.cpp
@@ -59,6 +59,9 @@ void TabItem::setCurrentPath(const QString& path) {
 
         QSettings settings("prism", "prism");
         settings.setValue("session/lastPath", m_currentPath);
+
+        if (auto* manager = qobject_cast<TabManager*>(parent()))
+            manager->saveSession();
     }
 }
 
@@ -153,10 +156,40 @@ TabManager::TabManager(QObject* parent)
     if (startupPath.isEmpty() || !QDir(startupPath).exists()) {
         startupPath = QDir::homePath();
     }
-    newTab(startupPath);
-    if (!m_tabs.isEmpty()) {
-        m_tabs.first()->setViewMode(defViewMode);
+
+    QStringList restored;
+    if (settings.value("preferences/restoreTabs", false).toBool()) {
+        const QStringList saved = settings.value("session/tabPaths").toStringList();
+        for (const QString& path : saved) {
+            if (!path.isEmpty() && (QDir(path).exists() || path.startsWith(QLatin1String("recent:"))))
+                restored.append(path);
+        }
     }
+
+    if (restored.isEmpty()) {
+        newTab(startupPath);
+    } else {
+        for (const QString& path : std::as_const(restored))
+            newTab(path);
+
+        const int savedIndex = settings.value("session/currentTab", 0).toInt();
+        if (savedIndex >= 0 && savedIndex < m_tabs.size())
+            setCurrentIndex(savedIndex);
+    }
+
+    for (TabItem* tab : std::as_const(m_tabs))
+        tab->setViewMode(defViewMode);
+}
+
+void TabManager::saveSession() {
+    QStringList paths;
+    paths.reserve(m_tabs.size());
+    for (const TabItem* tab : std::as_const(m_tabs))
+        paths.append(tab->currentPath());
+
+    QSettings settings("prism", "prism");
+    settings.setValue("session/tabPaths", paths);
+    settings.setValue("session/currentTab", m_currentIndex);
 }
 
 TabManager* TabManager::instance() {
@@ -251,6 +284,7 @@ void TabManager::newTab(const QString& path) {
     endInsertRows();
     emit countChanged();
     setCurrentIndex(idx);
+    saveSession();
 }
 
 void TabManager::closeTab(int index) {
@@ -268,6 +302,7 @@ void TabManager::closeTab(int index) {
     }
     emit currentTabChanged();
     emit countChanged();
+    saveSession();
 }
 
 void TabManager::duplicateTab(int index) {

--- a/src/controllers/tabmanager.hpp
+++ b/src/controllers/tabmanager.hpp
@@ -108,6 +108,7 @@ public:
 
     Q_INVOKABLE void newTab(const QString& path = "");
     Q_INVOKABLE void closeTab(int index);
+    void saveSession();
     Q_INVOKABLE void duplicateTab(int index);
     Q_INVOKABLE void moveTab(int fromIndex, int toIndex);
     Q_INVOKABLE void toggleSplitView();

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -38,6 +38,7 @@ AppController::AppController(QObject* parent)
     m_showHidden = settings.value("session/showHidden", legacy1.value("session/showHidden", legacy2.value("session/showHidden", false))).toBool();
     m_singleClick = settings.value("session/singleClick", legacy1.value("session/singleClick", legacy2.value("session/singleClick", false))).toBool();
     m_confirmPermanentDelete = settings.value("session/confirmPermanentDelete", true).toBool();
+    m_restoreTabs = settings.value("preferences/restoreTabs", false).toBool();
     m_defaultStartupDirectory = settings.value("preferences/startupDirectory", "home").toString();
     m_defaultViewMode = settings.value("preferences/defaultViewMode", 0).toInt();
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
@@ -118,6 +119,15 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         QSettings settings("prism", "prism");
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
+    }
+}
+
+void AppController::setRestoreTabs(bool restore) {
+    if (m_restoreTabs != restore) {
+        m_restoreTabs = restore;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/restoreTabs", restore);
+        emit restoreTabsChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -20,6 +20,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool directoryOnly READ directoryOnly WRITE setDirectoryOnly NOTIFY directoryOnlyChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool confirmPermanentDelete READ confirmPermanentDelete WRITE setConfirmPermanentDelete NOTIFY confirmPermanentDeleteChanged)
+    Q_PROPERTY(bool restoreTabs READ restoreTabs WRITE setRestoreTabs NOTIFY restoreTabsChanged)
     Q_PROPERTY(int dateFormat READ dateFormat WRITE setDateFormat NOTIFY dateFormatChanged)
     Q_PROPERTY(bool thumbnailsEnabled READ thumbnailsEnabled WRITE setThumbnailsEnabled NOTIFY thumbnailsEnabledChanged)
     Q_PROPERTY(int thumbnailMaxMb READ thumbnailMaxMb WRITE setThumbnailMaxMb NOTIFY thumbnailMaxMbChanged)
@@ -73,6 +74,9 @@ public:
     [[nodiscard]] bool showHidden() const { return m_showHidden; }
     [[nodiscard]] bool confirmPermanentDelete() const { return m_confirmPermanentDelete; }
     void setConfirmPermanentDelete(bool confirm);
+
+    [[nodiscard]] bool restoreTabs() const { return m_restoreTabs; }
+    void setRestoreTabs(bool restore);
     [[nodiscard]] int dateFormat() const { return m_dateFormat; }
     void setDateFormat(int format);
     Q_INVOKABLE static bool shiftPressed();
@@ -156,6 +160,7 @@ signals:
     void directoryOnlyChanged();
     void showHiddenChanged();
     void confirmPermanentDeleteChanged();
+    void restoreTabsChanged();
     void dateFormatChanged();
     void thumbnailsEnabledChanged();
     void thumbnailMaxMbChanged();
@@ -187,6 +192,7 @@ private:
     bool m_directoryOnly = false;
     bool m_showHidden = false;
     bool m_confirmPermanentDelete = true;
+    bool m_restoreTabs = false;
     int m_dateFormat = 1;
     bool m_thumbnailsEnabled = true;
     int m_thumbnailMaxMb = 0;


### PR DESCRIPTION
## Problem

`TabItem::setCurrentPath` writes `session/lastPath` and that is the whole of the session. A window with eight tabs reopens with one, on the last path whichever tab happened to touch it last. Thunar keeps the list behind `last-restore-tabs`.

## Change

`saveSession()` writes the tab paths and the active index. It runs when a tab is opened, when one is closed, and when any tab navigates, so the stored list is never behind what is on screen.

At startup, with `restoreTabs` on, the tabs are rebuilt from that list and the active one restored. Off by default, matching Thunar.

**A stale entry cannot break the window.** Paths that no longer exist are dropped, and if nothing survives the ordinary startup directory is used instead, so restoring a session that pointed at an unmounted drive still opens somewhere usable. `recent:///` is kept deliberately, since it has no directory to test.

The default view mode is now applied to every restored tab rather than only the first, which was previously the only tab there was.

## Verified

Opening three tabs writes `tabPaths=/home/vladi, /home/vladi/Dokumente, /home/vladi/Bilder` and `currentTab=2`. Restarting brings back all three in order with Bilder active. With the preference off, the same stored session yields one tab.
