### PR TITLE
feat: optionally show how many items a folder holds

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -64,6 +64,19 @@ MouseArea {
     ]
     readonly property var viewModeValues: [0, 1, 2]
 
+    readonly property list<MenuItem> folderCountItems: [
+        MenuItem {
+            text: qsTr("Never")
+        },
+        MenuItem {
+            text: qsTr("Local files only")
+        },
+        MenuItem {
+            text: qsTr("Always")
+        }
+    ]
+    readonly property var folderCountValues: [0, 1, 2]
+
     readonly property list<MenuItem> dateFormatItems: [
         MenuItem {
             text: qsTr("ISO (YYYY-MM-DD)")
@@ -524,6 +537,18 @@ MouseArea {
                                 color: Colours.palette.m3primary
                                 font: Tokens.font.label.large
                             }
+
+                            SplitButtonRow {
+                                first: true
+                                last: true
+                                label: qsTr("Show Item Count for Folders")
+                                subtext: qsTr("Counting reads every folder in the listing, which is slow over a network")
+                                menuItems: root.folderCountItems
+                                active: root.folderCountItems[Math.max(0, root.folderCountValues.indexOf(AppController.folderItemCount))]
+                                onSelected: item => AppController.folderItemCount = root.folderCountValues[root.folderCountItems.indexOf(item)]
+                            }
+
+                            Item { implicitHeight: 4 }
 
                             SplitButtonRow {
                                 first: true

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -230,7 +230,7 @@ Item {
             return "";
         switch (key) {
         case "size":
-            return file.isDir ? "" : file.formattedSize;
+            return file.formattedSize;
         case "type":
             return file.mimeDescription;
         case "date":

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -41,6 +41,10 @@ StyledRect {
 
     Connections {
         target: AppController
+        function onFolderItemCountChanged() {
+            if (mainModel) mainModel.refresh();
+            if (splitModel) splitModel.refresh();
+        }
         function onDateFormatChanged() {
             if (mainModel) mainModel.refresh();
             if (splitModel) splitModel.refresh();

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -44,6 +44,8 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+    m_folderItemCount = settings.value("preferences/folderItemCount", 0).toInt();
+    FileUtils::setFolderCountMode(m_folderItemCount);
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
     FileUtils::setDateFormat(m_dateFormat);
     m_thumbnailsEnabled = settings.value("preferences/thumbnailsEnabled", true).toBool();
@@ -118,6 +120,16 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         QSettings settings("prism", "prism");
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
+    }
+}
+
+void AppController::setFolderItemCount(int mode) {
+    if (m_folderItemCount != mode) {
+        m_folderItemCount = mode;
+        FileUtils::setFolderCountMode(mode);
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/folderItemCount", mode);
+        emit folderItemCountChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -36,6 +36,7 @@ class AppController : public QObject {
     Q_PROPERTY(int defaultSortOrder READ defaultSortOrder WRITE setDefaultSortOrder NOTIFY defaultSortOrderChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
+    Q_PROPERTY(int folderItemCount READ folderItemCount WRITE setFolderItemCount NOTIFY folderItemCountChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
     Q_PROPERTY(bool menuShowSecondaryEditor READ menuShowSecondaryEditor WRITE setMenuShowSecondaryEditor NOTIFY menuPreferencesChanged)
@@ -118,6 +119,9 @@ public:
     [[nodiscard]] int placesIconSize() const { return m_placesIconSize; }
     void setPlacesIconSize(int size);
 
+    [[nodiscard]] int folderItemCount() const { return m_folderItemCount; }
+    void setFolderItemCount(int mode);
+
     [[nodiscard]] QString selectedPath() const { return m_selectedPath; }
     void setSelectedPath(const QString& path);
 
@@ -172,6 +176,7 @@ signals:
     void defaultSortOrderChanged();
     void showDirsFirstChanged();
     void placesIconSizeChanged();
+    void folderItemCountChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
     void menuPreferencesChanged();
@@ -203,6 +208,7 @@ private:
     int m_defaultSortOrder = 0;
     bool m_showDirsFirst = true;
     int m_placesIconSize = 20;
+    int m_folderItemCount = 0;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;
     bool m_menuShowSecondaryEditor = true;

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -6,6 +6,8 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeDatabase>
+#include <QDirIterator>
+#include <QStorageInfo>
 #include <QStandardPaths>
 #include <QIcon>
 #include <QRegularExpression>
@@ -46,6 +48,7 @@ namespace {
 std::atomic<int> g_dateFormat{FileUtils::Iso};
 std::atomic<bool> g_thumbsEnabled{true};
 std::atomic<qint64> g_thumbMaxBytes{0};
+std::atomic<int> g_folderCountMode{FileUtils::FolderCountNever};
 }
 
 void FileUtils::setDateFormat(int format) {
@@ -89,6 +92,40 @@ bool FileUtils::shouldThumbnail(bool isImage, bool isVideo, qint64 size) {
 
     const qint64 limit = g_thumbMaxBytes.load(std::memory_order_relaxed);
     return limit <= 0 || size <= limit;
+}
+
+void FileUtils::setFolderCountMode(int mode) {
+    g_folderCountMode.store(mode, std::memory_order_relaxed);
+}
+
+int FileUtils::folderCountMode() {
+    return g_folderCountMode.load(std::memory_order_relaxed);
+}
+
+QString FileUtils::countFolderItems(const QString& path) {
+    const int mode = g_folderCountMode.load(std::memory_order_relaxed);
+    if (mode == FolderCountNever)
+        return {};
+
+    if (mode == FolderCountLocalOnly) {
+        const QStorageInfo storage(path);
+        const QByteArray device = storage.device();
+        if (!device.startsWith('/'))
+            return {};
+    }
+
+    QDir dir(path);
+    if (!dir.isReadable())
+        return {};
+
+    int count = 0;
+    QDirIterator it(path, QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden | QDir::System);
+    while (it.hasNext()) {
+        it.next();
+        ++count;
+    }
+
+    return count == 1 ? QObject::tr("1 item") : QObject::tr("%1 items").arg(count);
 }
 
 QString FileUtils::formatSize(qint64 bytes) {

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -45,6 +45,17 @@ public:
     static int dateFormat();
     Q_INVOKABLE static bool shouldThumbnail(bool isImage, bool isVideo, qint64 size);
     static void setThumbnailsEnabled(bool enabled);
+
+    enum FolderCount {
+        FolderCountNever = 0,
+        FolderCountLocalOnly = 1,
+        FolderCountAlways = 2
+    };
+    Q_ENUM(FolderCount)
+
+    static void setFolderCountMode(int mode);
+    static int folderCountMode();
+    static QString countFolderItems(const QString& path);
     static void setThumbnailMaxBytes(qint64 bytes);
     Q_INVOKABLE static QString shortenHome(const QString& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -197,7 +197,8 @@ static RawEntryData createRawDataFromInfo(const QFileInfo& fi, const QMimeDataba
     d.isSymLink = fi.isSymLink();
     d.symLinkTarget = fi.symLinkTarget();
     d.size = fi.isDir() ? 0 : fi.size();
-    d.formattedSize = fi.isDir() ? QString() : prism::core::FileUtils::formatSize(d.size);
+    d.formattedSize = fi.isDir() ? prism::core::FileUtils::countFolderItems(fi.absoluteFilePath())
+                                 : prism::core::FileUtils::formatSize(d.size);
     d.suffix = fi.suffix();
     d.isHidden = fi.isHidden() || d.name.startsWith('.');
     d.isWritable = fi.isWritable();


### PR DESCRIPTION
## Problem

The size column is empty for directories. Twice over, in fact: the model writes an empty string for a directory, and `FileDetailsView` blanks it again in `cellText` regardless of what the model said. Thunar fills it through `misc-folder-item-count`.

## Change

Three states, matching Thunar: **never**, **local files only**, **always**.

Never remains the default. Counting means opening every directory in the listing, and on a network mount that turns a directory change into a stall — which is exactly why Thunar has a three-way setting rather than a checkbox, and the middle state exists.

The count runs inside the existing worker scan rather than on the GUI thread, and the scan generation token means changing directory part way through abandons the work instead of finishing it for a listing nobody is looking at.

Local detection asks `QStorageInfo` whether the device path starts with a slash, which separates a real block device from gvfs, nfs and the like.

The mode is cached in an atomic next to the existing date-format and thumbnail caches, since the worker thread cannot touch `AppController`.

## Verified

With counting on, `~/src` shows `PrismFiles — 10 items`, which matches `ls -A`. With it off the cell is empty again. Changing the setting refreshes the open panes through the same hook the date format and thumbnail settings already use.
