### PR TITLE
fix: connect the sorting preferences to the views

### DIFF
--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -16,6 +16,7 @@ Item {
         id: fsModel
         path: root.dialog.currentPath
         showHidden: root.dialog.showHidden
+        showDirsFirst: AppController.showDirsFirst
         onPathChanged: view.currentIndex = -1
     }
 

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -41,6 +41,15 @@ StyledRect {
 
     Connections {
         target: AppController
+        function onDefaultSortFieldChanged() {
+            if (mainModel) mainModel.sortField = AppController.defaultSortField;
+            if (splitModel) splitModel.sortField = AppController.defaultSortField;
+        }
+        function onDefaultSortOrderChanged() {
+            const order = AppController.defaultSortOrder === 0 ? Qt.AscendingOrder : Qt.DescendingOrder;
+            if (mainModel) mainModel.sortOrder = order;
+            if (splitModel) splitModel.sortOrder = order;
+        }
         function onDateFormatChanged() {
             if (mainModel) mainModel.refresh();
             if (splitModel) splitModel.refresh();
@@ -101,6 +110,12 @@ StyledRect {
                 path: root.activeTab ? root.activeTab.currentPath : ""
                 searchQuery: (root.isSplit && root.activePane === 1) ? "" : root.searchQuery
                 showHidden: AppController.showHidden
+                showDirsFirst: AppController.showDirsFirst
+
+                Component.onCompleted: {
+                    sortField = AppController.defaultSortField;
+                    sortOrder = AppController.defaultSortOrder === 0 ? Qt.AscendingOrder : Qt.DescendingOrder;
+                }
             }
 
             Loader {
@@ -218,6 +233,12 @@ StyledRect {
                 path: (root.activeTab && root.activeTab.splitPath) ? root.activeTab.splitPath : ""
                 searchQuery: (root.isSplit && root.activePane === 1) ? root.searchQuery : ""
                 showHidden: AppController.showHidden
+                showDirsFirst: AppController.showDirsFirst
+
+                Component.onCompleted: {
+                    sortField = AppController.defaultSortField;
+                    sortOrder = AppController.defaultSortOrder === 0 ? Qt.AscendingOrder : Qt.DescendingOrder;
+                }
             }
 
             Loader {


### PR DESCRIPTION
## Problem

Turning Folders First off changes nothing.

The comparator is correct — it checks `m_showDirsFirst` before comparing — but **nothing ever assigns that property**. The three `FileSystemModel` instances bind `path`, `searchQuery` and `showHidden` and stop there, so the model keeps its own default of `true` for the life of the process. The preference writes a value that is read by nobody.

Checking the neighbours, **Default Sort Field and Default Sort Order are dead in the same way**. They are written by the preferences and never reach a model either, so the sort has always been name-ascending regardless.

This is the same shape as the git panel in #32: a complete implementation on both ends with no wire between them.

## Change

`showDirsFirst` is bound on both pane models and on the model behind the file picker, so it takes effect immediately.

The sort defaults are applied when a model is created and again when the preference changes. They are assigned rather than bound, because clicking a column header assigns the same properties and a binding would fight it — the header wins until the preference is touched again. That also matches how the setting describes itself, "Primary criterion for sorting file entries", rather than something that only applies to new windows.

## Verified

Rendered side by side in the same directory: with the toggle off the listing is plain alphabetical, `.git`, `.gitignore`, `assets`, `build`, `CMakeLists.txt`; with it on the directories come first, `.git`, `assets`, `build`, `qml`, `src`, then `.gitignore`.

For the sort defaults, the model reports field 0 order 0 at startup, and field 1 order 1 after changing both preferences.
