### PR TITLE
feat: remember the view mode and sort order per folder

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -328,6 +328,29 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "folder_managed"
+                                    text: qsTr("Remember View per Folder")
+                                    subtext: qsTr("Keep the view mode and sort order each folder was last left in")
+                                    checked: AppController.directorySpecificViews
+                                    onToggled: checked => AppController.directorySpecificViews = checked
+                                }
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    visible: AppController.directorySpecificViews
+                                    spacing: Tokens.spacing.small
+
+                                    Item { Layout.fillWidth: true }
+
+                                    TextButton {
+                                        type: ButtonBase.Text
+                                        text: qsTr("Forget saved folder views")
+                                        onClicked: AppController.forgetDirectoryViews()
+                                    }
+                                }
+
+
+                                ToggleRow {
                                     icon: "image"
                                     text: qsTr("Show Thumbnails")
                                     subtext: qsTr("Preview images and videos instead of generic icons")

--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -375,7 +375,7 @@ MouseArea {
                                     }
                                 }
 
-
+                                ToggleRow {
                                     icon: "tab_duplicate"
                                     text: qsTr("Restore Tabs on Startup")
                                     subtext: qsTr("Reopen the tabs that were open when the window was last closed")

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -39,6 +39,44 @@ StyledRect {
     }
     readonly property var activeModel: (isSplit && activePane === 1) ? splitModel : mainModel
 
+    property bool applyingDirectoryView: false
+
+    function applyDirectoryView() {
+        if (!AppController.directorySpecificViews || !root.activeTab)
+            return;
+
+        const stored = AppController.directoryView(root.activeTab.currentPath);
+        const known = stored && stored.viewMode !== undefined;
+
+        root.applyingDirectoryView = true;
+        root.activeTab.viewMode = known ? stored.viewMode : AppController.defaultViewMode;
+        mainModel.sortField = known ? stored.sortField : AppController.defaultSortField;
+        mainModel.sortOrder = known ? stored.sortOrder
+                                    : (AppController.defaultSortOrder === 0 ? Qt.AscendingOrder : Qt.DescendingOrder);
+        root.applyingDirectoryView = false;
+    }
+
+    function rememberDirectoryView() {
+        if (!AppController.directorySpecificViews || root.applyingDirectoryView || !root.activeTab)
+            return;
+        AppController.rememberDirectoryView(root.activeTab.currentPath,
+                                            root.activeTab.viewMode,
+                                            mainModel.sortField,
+                                            mainModel.sortOrder);
+    }
+
+    Connections {
+        target: root.activeTab
+        function onCurrentPathChanged() { root.applyDirectoryView(); }
+        function onViewModeChanged() { root.rememberDirectoryView(); }
+    }
+
+    Connections {
+        target: mainModel
+        function onSortFieldChanged() { root.rememberDirectoryView(); }
+        function onSortOrderChanged() { root.rememberDirectoryView(); }
+    }
+
     Connections {
         target: AppController
         function onDateFormatChanged() {

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -43,6 +43,11 @@ AppController::AppController(QObject* parent)
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
+    m_directorySpecificViews = settings.value("preferences/directorySpecificViews", false).toBool();
+
+    const QByteArray viewsJson = settings.value("preferences/directoryViews").toString().toUtf8();
+    if (!viewsJson.isEmpty())
+        m_directoryViews = QJsonDocument::fromJson(viewsJson).object().toVariantMap();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
     FileUtils::setDateFormat(m_dateFormat);
@@ -119,6 +124,56 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
     }
+}
+
+void AppController::setDirectorySpecificViews(bool enabled) {
+    if (m_directorySpecificViews == enabled)
+        return;
+
+    m_directorySpecificViews = enabled;
+
+    QSettings settings("prism", "prism");
+    settings.setValue("preferences/directorySpecificViews", enabled);
+    emit directorySpecificViewsChanged();
+}
+
+QVariantMap AppController::directoryView(const QString& path) const {
+    if (!m_directorySpecificViews || path.isEmpty())
+        return {};
+    return m_directoryViews.value(path).toMap();
+}
+
+void AppController::rememberDirectoryView(const QString& path, int viewMode, int sortField, int sortOrder) {
+    if (!m_directorySpecificViews || path.isEmpty())
+        return;
+
+    QVariantMap entry;
+    entry.insert(QStringLiteral("viewMode"), viewMode);
+    entry.insert(QStringLiteral("sortField"), sortField);
+    entry.insert(QStringLiteral("sortOrder"), sortOrder);
+
+    if (m_directoryViews.value(path).toMap() == entry)
+        return;
+
+    m_directoryViews.remove(path);
+    m_directoryViews.insert(path, entry);
+
+    while (m_directoryViews.size() > 300)
+        m_directoryViews.erase(m_directoryViews.begin());
+
+    QSettings settings("prism", "prism");
+    settings.setValue("preferences/directoryViews",
+                      QString::fromUtf8(QJsonDocument(QJsonObject::fromVariantMap(m_directoryViews)).toJson(QJsonDocument::Compact)));
+}
+
+void AppController::forgetDirectoryViews() {
+    if (m_directoryViews.isEmpty())
+        return;
+
+    m_directoryViews.clear();
+
+    QSettings settings("prism", "prism");
+    settings.remove("preferences/directoryViews");
 }
 
 void AppController::setDateFormat(int format) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -35,6 +35,7 @@ class AppController : public QObject {
     Q_PROPERTY(int defaultSortField READ defaultSortField WRITE setDefaultSortField NOTIFY defaultSortFieldChanged)
     Q_PROPERTY(int defaultSortOrder READ defaultSortOrder WRITE setDefaultSortOrder NOTIFY defaultSortOrderChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
+    Q_PROPERTY(bool directorySpecificViews READ directorySpecificViews WRITE setDirectorySpecificViews NOTIFY directorySpecificViewsChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
@@ -115,6 +116,12 @@ public:
     [[nodiscard]] bool showDirsFirst() const { return m_showDirsFirst; }
     void setShowDirsFirst(bool dirsFirst);
 
+    [[nodiscard]] bool directorySpecificViews() const { return m_directorySpecificViews; }
+    void setDirectorySpecificViews(bool enabled);
+    Q_INVOKABLE QVariantMap directoryView(const QString& path) const;
+    Q_INVOKABLE void rememberDirectoryView(const QString& path, int viewMode, int sortField, int sortOrder);
+    Q_INVOKABLE void forgetDirectoryViews();
+
     [[nodiscard]] int placesIconSize() const { return m_placesIconSize; }
     void setPlacesIconSize(int size);
 
@@ -171,6 +178,7 @@ signals:
     void defaultSortFieldChanged();
     void defaultSortOrderChanged();
     void showDirsFirstChanged();
+    void directorySpecificViewsChanged();
     void placesIconSizeChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
@@ -202,6 +210,8 @@ private:
     int m_defaultSortField = 0;
     int m_defaultSortOrder = 0;
     bool m_showDirsFirst = true;
+    bool m_directorySpecificViews = false;
+    QVariantMap m_directoryViews;
     int m_placesIconSize = 20;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;


### PR DESCRIPTION
## Problem

Prism has one view mode and one sort order for everything. A folder of photos wants a grid, a source tree wants the details list, and switching between them means switching the view by hand every time. Thunar keeps this per directory behind `misc-directory-specific-settings`.

## Change

The view mode, sort field and sort order are stored against the path whenever any of them changes, and applied when that path is opened again. Off by default, matching Thunar.

**A folder with nothing stored falls back to the global defaults**, not to whatever the previous folder was using. This is the part worth arguing for: without it, setting one folder to details quietly converts every folder visited afterwards, and the feature makes the application feel less predictable rather than more. I built it the other way first and the result was exactly that — going from a folder set to details back to an unvisited one left it in details.

The store is a JSON map in the settings, capped at 300 folders with the oldest dropped, and there is a button under the toggle to clear it rather than leaving an unreachable pile of state.

An `applyingDirectoryView` guard stops the apply from immediately writing back what it just read.

## Verified

With the setting on: Bilder set to compact and PrismFiles to details, then navigating back and forth, each returns to its own mode. A third folder never visited opens in the global default rather than in the mode of the folder before it.
