### PR TITLE
feat: select files by pattern

### DIFF
--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -428,6 +428,34 @@ StyledRect {
         }
     }
 
+    function selectByPattern(pattern) {
+        const trimmed = (pattern || "").trim();
+        if (trimmed.length === 0)
+            return;
+
+        const escaped = trimmed.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+                               .replace(/\*/g, ".*")
+                               .replace(/\?/g, ".");
+        let matcher;
+        try {
+            matcher = new RegExp("^" + escaped + "$", "i");
+        } catch (e) {
+            return;
+        }
+
+        const loader = (isSplit && activePane === 1) ? splitViewLoader : mainViewLoader;
+        if (!activeModel || !loader || !loader.item)
+            return;
+
+        let matched = [];
+        for (let i = 0; i < activeModel.count; ++i) {
+            const e = activeModel.get(i);
+            if (e && matcher.test(e.name))
+                matched.push(e.path);
+        }
+        loader.item.selectedPaths = matched;
+    }
+
     function invertSelection() {
         let loader = (isSplit && activePane === 1) ? splitViewLoader : mainViewLoader;
         if (activeModel && loader && loader.item) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -480,6 +480,8 @@ ApplicationWindow {
                     FileOperations.createDirectory(currentDir, text);
                 } else if (title === qsTr("Create New File")) {
                     FileOperations.createFile(currentDir, text);
+                } else if (title === qsTr("Select by Pattern")) {
+                    splitContainer.selectByPattern(text);
                 } else if (title === qsTr("Rename")) {
                     let oldPath = newItemModal.targetRenamePath || (contextMenu.targetItem ? contextMenu.targetItem.path : "");
                     if (oldPath) {
@@ -774,6 +776,17 @@ ApplicationWindow {
             sequence: "Ctrl+I"
             context: Qt.ApplicationShortcut
             onActivated: splitContainer.invertSelection()
+        }
+
+        Shortcut {
+            sequence: "Ctrl+S"
+            context: Qt.ApplicationShortcut
+            onActivated: {
+                newItemModal.title = qsTr("Select by Pattern");
+                newItemModal.icon = "filter_alt";
+                newItemModal.initialText = "*";
+                newItemModal.expanded = true;
+            }
         }
 
         Shortcut {


### PR DESCRIPTION
## Problem

Prism has Select All and Invert Selection but no way to say "every `.png` in here". Thunar has it on Ctrl+S, which is free in Prism.

## Change

Ctrl+S opens the existing name dialog with `*` prefilled, and the pattern selects the matching entries in the active pane.

The glob is translated to a regular expression rather than matched by hand. The characters that mean something in both syntaxes are escaped first, so `notes (1).txt` matches literally instead of the brackets being read as a group, and only `*` and `?` are then turned into `.*` and `.`. A malformed pattern is ignored rather than throwing out of the binding.

Matching ignores case. Globbing in a file manager is a convenience, not a shell contract, and `*.PNG` failing to match `photo.png` would be surprising rather than correct.

## Verified

Against a directory of three `.png`, three `.txt` and one `.md`: `*.png` selects the three images, `text?.txt` selects the three text files, `*` selects all seven.
