### PR TITLE
feat: make sorting case sensitivity a setting

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -602,6 +602,15 @@ MouseArea {
                                     checked: AppController.showDirsFirst
                                     onToggled: val => AppController.showDirsFirst = val
                                 }
+
+                                ToggleRow {
+                                    icon: "match_case"
+                                    text: qsTr("Case-Sensitive Sorting")
+                                    subtext: qsTr("Sort uppercase names before lowercase ones instead of mixing them")
+                                    checked: AppController.caseSensitiveSort
+                                    onToggled: checked => AppController.caseSensitiveSort = checked
+                                }
+
                             }
 
                             Item { implicitHeight: Tokens.padding.small }

--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -16,6 +16,7 @@ Item {
         id: fsModel
         path: root.dialog.currentPath
         showHidden: root.dialog.showHidden
+        caseSensitiveSort: AppController.caseSensitiveSort
         onPathChanged: view.currentIndex = -1
     }
 

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -101,6 +101,7 @@ StyledRect {
                 path: root.activeTab ? root.activeTab.currentPath : ""
                 searchQuery: (root.isSplit && root.activePane === 1) ? "" : root.searchQuery
                 showHidden: AppController.showHidden
+                caseSensitiveSort: AppController.caseSensitiveSort
             }
 
             Loader {
@@ -218,6 +219,7 @@ StyledRect {
                 path: (root.activeTab && root.activeTab.splitPath) ? root.activeTab.splitPath : ""
                 searchQuery: (root.isSplit && root.activePane === 1) ? root.searchQuery : ""
                 showHidden: AppController.showHidden
+                caseSensitiveSort: AppController.caseSensitiveSort
             }
 
             Loader {

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -43,6 +43,7 @@ AppController::AppController(QObject* parent)
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
+    m_caseSensitiveSort = settings.value("preferences/caseSensitiveSort", false).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
     FileUtils::setDateFormat(m_dateFormat);
@@ -118,6 +119,15 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         QSettings settings("prism", "prism");
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
+    }
+}
+
+void AppController::setCaseSensitiveSort(bool sensitive) {
+    if (m_caseSensitiveSort != sensitive) {
+        m_caseSensitiveSort = sensitive;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/caseSensitiveSort", sensitive);
+        emit caseSensitiveSortChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -35,6 +35,7 @@ class AppController : public QObject {
     Q_PROPERTY(int defaultSortField READ defaultSortField WRITE setDefaultSortField NOTIFY defaultSortFieldChanged)
     Q_PROPERTY(int defaultSortOrder READ defaultSortOrder WRITE setDefaultSortOrder NOTIFY defaultSortOrderChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
+    Q_PROPERTY(bool caseSensitiveSort READ caseSensitiveSort WRITE setCaseSensitiveSort NOTIFY caseSensitiveSortChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
@@ -115,6 +116,9 @@ public:
     [[nodiscard]] bool showDirsFirst() const { return m_showDirsFirst; }
     void setShowDirsFirst(bool dirsFirst);
 
+    [[nodiscard]] bool caseSensitiveSort() const { return m_caseSensitiveSort; }
+    void setCaseSensitiveSort(bool sensitive);
+
     [[nodiscard]] int placesIconSize() const { return m_placesIconSize; }
     void setPlacesIconSize(int size);
 
@@ -171,6 +175,7 @@ signals:
     void defaultSortFieldChanged();
     void defaultSortOrderChanged();
     void showDirsFirstChanged();
+    void caseSensitiveSortChanged();
     void placesIconSizeChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
@@ -202,6 +207,7 @@ private:
     int m_defaultSortField = 0;
     int m_defaultSortOrder = 0;
     bool m_showDirsFirst = true;
+    bool m_caseSensitiveSort = false;
     int m_placesIconSize = 20;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -137,6 +137,14 @@ void FileSystemModel::setShowDirsFirst(bool dirsFirst) {
     }
 }
 
+void FileSystemModel::setCaseSensitiveSort(bool sensitive) {
+    if (m_caseSensitiveSort != sensitive) {
+        m_caseSensitiveSort = sensitive;
+        emit caseSensitiveSortChanged();
+        applyFilterAndSort();
+    }
+}
+
 void FileSystemModel::setSortField(SortField field) {
     if (m_sortField != field) {
         m_sortField = field;
@@ -568,6 +576,13 @@ QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<
     collator.setCaseSensitivity(Qt::CaseInsensitive);
     collator.setNumericMode(true);
 
+    const bool caseSensitive = m_caseSensitiveSort;
+    auto compareText = [&collator, caseSensitive](const QString& a, const QString& b) -> int {
+        if (caseSensitive)
+            return QString::compare(a, b, Qt::CaseSensitive);
+        return collator.compare(a, b);
+    };
+
     auto comparator = [&](FileSystemEntry* a, FileSystemEntry* b) -> bool {
         if (m_showDirsFirst && a->isDir() != b->isDir()) {
             return a->isDir();
@@ -576,21 +591,21 @@ QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<
         int res = 0;
         switch (m_sortField) {
         case SortByName:
-            res = collator.compare(a->name(), b->name());
+            res = compareText(a->name(), b->name());
             break;
         case SortBySize:
             if (a->size() < b->size()) res = -1;
             else if (a->size() > b->size()) res = 1;
-            else res = collator.compare(a->name(), b->name());
+            else res = compareText(a->name(), b->name());
             break;
         case SortByDate:
             if (a->lastModified() < b->lastModified()) res = -1;
             else if (a->lastModified() > b->lastModified()) res = 1;
-            else res = collator.compare(a->name(), b->name());
+            else res = compareText(a->name(), b->name());
             break;
         case SortByType:
-            res = collator.compare(a->mimeDescription(), b->mimeDescription());
-            if (res == 0) res = collator.compare(a->name(), b->name());
+            res = compareText(a->mimeDescription(), b->mimeDescription());
+            if (res == 0) res = compareText(a->name(), b->name());
             break;
         }
 

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -145,6 +145,7 @@ class FileSystemModel : public QAbstractListModel {
     Q_PROPERTY(QStringList nameFilters READ nameFilters WRITE setNameFilters NOTIFY nameFiltersChanged)
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
+    Q_PROPERTY(bool caseSensitiveSort READ caseSensitiveSort WRITE setCaseSensitiveSort NOTIFY caseSensitiveSortChanged)
     Q_PROPERTY(SortField sortField READ sortField WRITE setSortField NOTIFY sortFieldChanged)
     Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder NOTIFY sortOrderChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
@@ -203,6 +204,9 @@ public:
     bool showDirsFirst() const { return m_showDirsFirst; }
     void setShowDirsFirst(bool dirsFirst);
 
+    bool caseSensitiveSort() const { return m_caseSensitiveSort; }
+    void setCaseSensitiveSort(bool sensitive);
+
     SortField sortField() const { return m_sortField; }
     void setSortField(SortField field);
 
@@ -225,6 +229,7 @@ signals:
     void nameFiltersChanged();
     void showHiddenChanged();
     void showDirsFirstChanged();
+    void caseSensitiveSortChanged();
     void sortFieldChanged();
     void sortOrderChanged();
     void countChanged();
@@ -247,6 +252,7 @@ private:
     QStringList m_nameFilters;
     bool m_showHidden = false;
     bool m_showDirsFirst = true;
+    bool m_caseSensitiveSort = false;
     SortField m_sortField = SortByName;
     Qt::SortOrder m_sortOrder = Qt::AscendingOrder;
 


### PR DESCRIPTION
## Problem

Sorting is always case insensitive; the collator is constructed with `Qt::CaseInsensitive` and nothing can change it. Thunar has `misc-case-sensitive`, off by default.

## Change

A setting, wired through to all three models, off by default.

**Flipping the collator is not enough**, which is worth writing down because it is the obvious first attempt and it looks like a wiring bug. `QCollator::setCaseSensitivity(Qt::CaseSensitive)` treats case as a tertiary difference, the way ICU collation is specified: `Alpha` and `apfel` still compare on their base letters, so `Alpha` stays between `apfel` and `banane` and the setting appears dead. I rendered it before and after and the two were pixel-identical.

What people mean by case-sensitive sorting in a file manager is code point order — uppercase before lowercase — so that is what the setting does. The default path keeps the collator, including its numeric mode, so `file2` still sorts before `file10`.

## Verified

A directory holding `Alpha.txt`, `apfel.txt`, `banane.txt`, `Beta.txt`, `Zebra.txt`, `zitrone.txt`:

- off: Alpha, apfel, banane, Beta, Zebra, zitrone
- on: Alpha, Beta, Zebra, apfel, banane, zitrone
