### PR TITLE
feat: allow a custom date format

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -73,10 +73,13 @@ MouseArea {
         },
         MenuItem {
             text: qsTr("Long (Date Time)")
+        },
+        MenuItem {
+            text: qsTr("Custom")
         }
     ]
     // Order matches dateFormatItems: ISO, Short, Long
-    readonly property var dateFormatValues: [1, 0, 2]
+    readonly property var dateFormatValues: [1, 0, 2, 3]
 
     readonly property list<MenuItem> iconSizeItems: [
         MenuItem {
@@ -527,12 +530,37 @@ MouseArea {
 
                             SplitButtonRow {
                                 first: true
-                                last: true
+                                last: AppController.dateFormat !== 3
                                 label: qsTr("Date Format")
                                 subtext: qsTr("Format: %1").arg(FileUtils.formatDateTime(new Date(), AppController.dateFormat))
                                 menuItems: root.dateFormatItems
                                 active: root.dateFormatItems[Math.max(0, root.dateFormatValues.indexOf(AppController.dateFormat))]
                                 onSelected: item => AppController.dateFormat = root.dateFormatValues[root.dateFormatItems.indexOf(item)]
+                            }
+
+                            StyledRect {
+                                visible: AppController.dateFormat === 3
+                                Layout.fillWidth: true
+                                implicitHeight: 42
+                                topLeftRadius: Tokens.rounding.extraSmall
+                                topRightRadius: Tokens.rounding.extraSmall
+                                bottomLeftRadius: Tokens.rounding.large
+                                bottomRightRadius: Tokens.rounding.large
+                                color: Colours.tPalette.m3surfaceContainer
+
+                                TextInput {
+                                    id: customDateInput
+                                    anchors.fill: parent
+                                    anchors.leftMargin: Tokens.padding.largeIncreased
+                                    anchors.rightMargin: Tokens.padding.largeIncreased
+                                    verticalAlignment: TextInput.AlignVCenter
+                                    text: AppController.customDateFormat
+                                    color: Colours.palette.m3onSurface
+                                    font: Tokens.font.body.small
+                                    selectByMouse: true
+                                    clip: true
+                                    onEditingFinished: AppController.customDateFormat = text
+                                }
                             }
 
                             Item { implicitHeight: 4 }

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -45,6 +45,8 @@ AppController::AppController(QObject* parent)
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
+    m_customDateFormat = settings.value("preferences/customDateFormat", "yyyy-MM-dd hh:mm").toString();
+    FileUtils::setCustomDateFormat(m_customDateFormat);
     FileUtils::setDateFormat(m_dateFormat);
     m_thumbnailsEnabled = settings.value("preferences/thumbnailsEnabled", true).toBool();
     m_thumbnailMaxMb = settings.value("preferences/thumbnailMaxMb", 0).toInt();
@@ -119,6 +121,18 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
     }
+}
+
+void AppController::setCustomDateFormat(const QString& pattern) {
+    if (m_customDateFormat == pattern)
+        return;
+
+    m_customDateFormat = pattern;
+    FileUtils::setCustomDateFormat(pattern);
+
+    QSettings settings("prism", "prism");
+    settings.setValue("preferences/customDateFormat", pattern);
+    emit customDateFormatChanged();
 }
 
 void AppController::setDateFormat(int format) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -21,6 +21,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden NOTIFY showHiddenChanged)
     Q_PROPERTY(bool confirmPermanentDelete READ confirmPermanentDelete WRITE setConfirmPermanentDelete NOTIFY confirmPermanentDeleteChanged)
     Q_PROPERTY(int dateFormat READ dateFormat WRITE setDateFormat NOTIFY dateFormatChanged)
+    Q_PROPERTY(QString customDateFormat READ customDateFormat WRITE setCustomDateFormat NOTIFY customDateFormatChanged)
     Q_PROPERTY(bool thumbnailsEnabled READ thumbnailsEnabled WRITE setThumbnailsEnabled NOTIFY thumbnailsEnabledChanged)
     Q_PROPERTY(int thumbnailMaxMb READ thumbnailMaxMb WRITE setThumbnailMaxMb NOTIFY thumbnailMaxMbChanged)
     Q_PROPERTY(bool showSizeColumn READ showSizeColumn WRITE setShowSizeColumn NOTIFY showSizeColumnChanged)
@@ -75,6 +76,9 @@ public:
     void setConfirmPermanentDelete(bool confirm);
     [[nodiscard]] int dateFormat() const { return m_dateFormat; }
     void setDateFormat(int format);
+
+    [[nodiscard]] QString customDateFormat() const { return m_customDateFormat; }
+    void setCustomDateFormat(const QString& pattern);
     Q_INVOKABLE static bool shiftPressed();
     [[nodiscard]] bool thumbnailsEnabled() const { return m_thumbnailsEnabled; }
     void setThumbnailsEnabled(bool enabled);
@@ -157,6 +161,7 @@ signals:
     void showHiddenChanged();
     void confirmPermanentDeleteChanged();
     void dateFormatChanged();
+    void customDateFormatChanged();
     void thumbnailsEnabledChanged();
     void thumbnailMaxMbChanged();
     void showSizeColumnChanged();
@@ -187,6 +192,7 @@ private:
     bool m_directoryOnly = false;
     bool m_showHidden = false;
     bool m_confirmPermanentDelete = true;
+    QString m_customDateFormat = QStringLiteral("yyyy-MM-dd hh:mm");
     int m_dateFormat = 1;
     bool m_thumbnailsEnabled = true;
     int m_thumbnailMaxMb = 0;

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -6,6 +6,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QMimeDatabase>
+#include <QReadWriteLock>
 #include <QStandardPaths>
 #include <QIcon>
 #include <QRegularExpression>
@@ -46,6 +47,8 @@ namespace {
 std::atomic<int> g_dateFormat{FileUtils::Iso};
 std::atomic<bool> g_thumbsEnabled{true};
 std::atomic<qint64> g_thumbMaxBytes{0};
+QReadWriteLock g_customDateLock;
+QString g_customDateFormat = QStringLiteral("yyyy-MM-dd hh:mm");
 }
 
 void FileUtils::setDateFormat(int format) {
@@ -54,6 +57,11 @@ void FileUtils::setDateFormat(int format) {
 
 int FileUtils::dateFormat() {
     return g_dateFormat.load(std::memory_order_relaxed);
+}
+
+void FileUtils::setCustomDateFormat(const QString& pattern) {
+    QWriteLocker locker(&g_customDateLock);
+    g_customDateFormat = pattern.trimmed().isEmpty() ? QStringLiteral("yyyy-MM-dd hh:mm") : pattern;
 }
 
 QString FileUtils::formatDateTime(const QDateTime& dt, int format) {
@@ -68,6 +76,13 @@ QString FileUtils::formatDateTime(const QDateTime& dt, int format) {
         return QLocale::system().toString(dt, QLocale::ShortFormat);
     case LongLocale:
         return QLocale::system().toString(dt, QLocale::LongFormat);
+    case Custom: {
+        QReadLocker locker(&g_customDateLock);
+        const QString pattern = g_customDateFormat;
+        locker.unlock();
+        const QString rendered = QLocale::system().toString(dt, pattern);
+        return rendered.isEmpty() ? dt.toString(QStringLiteral("yyyy-MM-dd hh:mm")) : rendered;
+    }
     default:
         return dt.toString(QStringLiteral("yyyy-MM-dd hh:mm"));
     }

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -35,7 +35,8 @@ public:
     enum DateFormat {
         SystemLocale = 0,
         Iso = 1,
-        LongLocale = 2
+        LongLocale = 2,
+        Custom = 3
     };
     Q_ENUM(DateFormat)
 
@@ -45,6 +46,7 @@ public:
     static int dateFormat();
     Q_INVOKABLE static bool shouldThumbnail(bool isImage, bool isVideo, qint64 size);
     static void setThumbnailsEnabled(bool enabled);
+    static void setCustomDateFormat(const QString& pattern);
     static void setThumbnailMaxBytes(qint64 bytes);
     Q_INVOKABLE static QString shortenHome(const QString& path);
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);


### PR DESCRIPTION
## Problem

Three date presets, and the long one is the reason the properties dialog overflowed in #30 — `Mittwoch, 8. Juli 2026 18:40:43 Mitteleuropäische Sommerzeit` is not a column heading. Thunar takes a format string through `misc-date-custom-style`.

## Change

A fourth choice, Custom, which reveals a pattern field directly below the selector and joins it visually as one group.

Rendering goes through `QLocale::system().toString(dt, pattern)` rather than `QDateTime::toString`, so `ddd d MMM` produces `So. 23 Aug.` on a German system rather than `Sun 23 Aug`. A format string that ignores the reader's language would be a strange thing to offer.

**An empty or unusable pattern falls back to the ISO form.** The field is edited live and passes through half-typed states; without the fallback every date cell in the window blanks out while you are still typing.

The pattern is held behind a read-write lock rather than an atomic, since it is a string read from the scan threads and written from the GUI thread.

## Verified

`dd.MM.yy HH:mm` gives `23.08.26 17:42`, `ddd d MMM` gives `So. 23 Aug.`, an empty pattern gives `2026-08-23 17:42`, and the other three presets are unaffected.
