### PR TITLE
feat: report free space in the status bar

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -320,6 +320,15 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "hard_drive_2"
+                                    text: qsTr("Show Free Space")
+                                    subtext: qsTr("Report the space left on the current volume in the status bar")
+                                    checked: AppController.showFreeSpace
+                                    onToggled: checked => AppController.showFreeSpace = checked
+                                }
+
+
+                                ToggleRow {
                                     icon: "delete_forever"
                                     text: qsTr("Confirm Permanent Deletion")
                                     subtext: qsTr("Ask before deleting files without using the trash (Shift+Delete)")

--- a/qml/components/statusbar/StatusBar.qml
+++ b/qml/components/statusbar/StatusBar.qml
@@ -43,6 +43,18 @@ StyledRect {
             font: Tokens.font.label.medium
         }
 
+        StyledText {
+            visible: AppController.showFreeSpace && text.length > 0
+            text: {
+                if (!AppController.showFreeSpace || !root.activeTab)
+                    return "";
+                const free = FileUtils.freeSpaceFor(root.activeTab.currentPath);
+                return free.length > 0 ? qsTr("•  %1 free").arg(free) : "";
+            }
+            color: Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.medium
+        }
+
         Item {
             Layout.fillWidth: true
         }

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -43,6 +43,7 @@ AppController::AppController(QObject* parent)
     m_defaultSortField = settings.value("preferences/defaultSortField", 0).toInt();
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
+    m_showFreeSpace = settings.value("preferences/showFreeSpace", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
     FileUtils::setDateFormat(m_dateFormat);
@@ -118,6 +119,15 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         QSettings settings("prism", "prism");
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
+    }
+}
+
+void AppController::setShowFreeSpace(bool show) {
+    if (m_showFreeSpace != show) {
+        m_showFreeSpace = show;
+        QSettings settings("prism", "prism");
+        settings.setValue("preferences/showFreeSpace", show);
+        emit showFreeSpaceChanged();
     }
 }
 

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -35,6 +35,7 @@ class AppController : public QObject {
     Q_PROPERTY(int defaultSortField READ defaultSortField WRITE setDefaultSortField NOTIFY defaultSortFieldChanged)
     Q_PROPERTY(int defaultSortOrder READ defaultSortOrder WRITE setDefaultSortOrder NOTIFY defaultSortOrderChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
+    Q_PROPERTY(bool showFreeSpace READ showFreeSpace WRITE setShowFreeSpace NOTIFY showFreeSpaceChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
@@ -115,6 +116,9 @@ public:
     [[nodiscard]] bool showDirsFirst() const { return m_showDirsFirst; }
     void setShowDirsFirst(bool dirsFirst);
 
+    [[nodiscard]] bool showFreeSpace() const { return m_showFreeSpace; }
+    void setShowFreeSpace(bool show);
+
     [[nodiscard]] int placesIconSize() const { return m_placesIconSize; }
     void setPlacesIconSize(int size);
 
@@ -171,6 +175,7 @@ signals:
     void defaultSortFieldChanged();
     void defaultSortOrderChanged();
     void showDirsFirstChanged();
+    void showFreeSpaceChanged();
     void placesIconSizeChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
@@ -202,6 +207,7 @@ private:
     int m_defaultSortField = 0;
     int m_defaultSortOrder = 0;
     bool m_showDirsFirst = true;
+    bool m_showFreeSpace = true;
     int m_placesIconSize = 20;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;

--- a/src/core/fileutils.cpp
+++ b/src/core/fileutils.cpp
@@ -7,6 +7,7 @@
 #include <QFileInfo>
 #include <QMimeDatabase>
 #include <QStandardPaths>
+#include <QStorageInfo>
 #include <QIcon>
 #include <QRegularExpression>
 
@@ -135,6 +136,17 @@ QVariantList FileUtils::describePaths(const QStringList& paths) {
     }
 
     return entries;
+}
+
+QString FileUtils::freeSpaceFor(const QString& path) {
+    if (path.isEmpty() || path.contains(QLatin1String("://")) || path.startsWith(QLatin1String("recent:")))
+        return {};
+
+    const QStorageInfo storage(path);
+    if (!storage.isValid() || !storage.isReady())
+        return {};
+
+    return formatSize(storage.bytesAvailable());
 }
 
 bool FileUtils::isImage(const QString& path) {

--- a/src/core/fileutils.hpp
+++ b/src/core/fileutils.hpp
@@ -50,6 +50,7 @@ public:
     Q_INVOKABLE static QString toLocalFile(const QUrl& url);
     Q_INVOKABLE static QString baseName(const QString& path);
     Q_INVOKABLE static QVariantList describePaths(const QStringList& paths);
+    Q_INVOKABLE static QString freeSpaceFor(const QString& path);
     Q_INVOKABLE static bool isImage(const QString& path);
     Q_INVOKABLE static bool isVideo(const QString& path);
     Q_INVOKABLE static bool isAudio(const QString& path);


### PR DESCRIPTION
## Problem

The status bar carries an item count, a selection summary and the git branch. Free space is not shown anywhere in the application, and it is one of the two things a file manager status bar is normally for. Thunar exposes it through `misc-status-bar-active-info`.

## Change

`FileUtils.freeSpaceFor(path)` returns the formatted space available on the volume holding a path, and the status bar shows it after the item count. On by default, with a toggle.

**Virtual locations return nothing.** `recent:///` and anything carrying a scheme are rejected before `QStorageInfo` sees them; otherwise the path string resolves to whichever filesystem happens to contain the current working directory and the bar reports a number that means nothing. The entry hides itself rather than showing a blank bullet.

## Verified

`204.7 GB` for the home volume against `205G` from `df`, and `1.4 GB` for `/boot` against `1.5G` — the difference is decimal against binary units, which is how `formatSize` already reports every other size in the application. `recent:///` and an empty path both return nothing. Rendered in the bar as `4 items · 204.7 GB free`.
