### PR TITLE
fix: do not leave a truncated file behind when a copy fails

### DIFF
--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -157,30 +157,61 @@ bool FileOperations::copyRecursively(const QString& src, const QString& dest, st
         if (!in.open(QIODevice::ReadOnly))
             return false;
 
-        QFile out(dest);
+        const QString partial = dest + QStringLiteral(".prism-partial");
+        QFile::remove(partial);
+
+        QFile out(partial);
         if (!out.open(QIODevice::WriteOnly))
             return false;
 
+        const auto abandon = [&out, &partial]() {
+            out.close();
+            QFile::remove(partial);
+            return false;
+        };
+
         QByteArray buf(64 * 1024, 0);
         while (!in.atEnd()) {
-            if (cancelFlag.load()) {
-                out.close();
-                QFile::remove(dest);
-                return false;
-            }
-            qint64 bytesRead = in.read(buf.data(), buf.size());
-            if (bytesRead > 0) {
-                out.write(buf.constData(), bytesRead);
-                processedBytes += bytesRead;
-                if (totalBytes > 0) {
-                    qreal p = static_cast<qreal>(processedBytes) / totalBytes;
-                    QMetaObject::invokeMethod(m_progress, [this, p, src]() {
-                        m_progress->setProgress(p);
-                        m_progress->setCurrentItem(src);
-                    });
-                }
+            if (cancelFlag.load())
+                return abandon();
+
+            const qint64 bytesRead = in.read(buf.data(), buf.size());
+            if (bytesRead < 0)
+                return abandon();
+            if (bytesRead == 0)
+                continue;
+
+            if (out.write(buf.constData(), bytesRead) != bytesRead)
+                return abandon();
+
+            processedBytes += bytesRead;
+            if (totalBytes > 0) {
+                qreal p = static_cast<qreal>(processedBytes) / totalBytes;
+                QMetaObject::invokeMethod(m_progress, [this, p, src]() {
+                    m_progress->setProgress(p);
+                    m_progress->setCurrentItem(src);
+                });
             }
         }
+
+        if (!out.flush())
+            return abandon();
+        out.close();
+        if (out.error() != QFile::NoError)
+            return abandon();
+
+        out.setPermissions(srcInfo.permissions());
+
+        if (QFileInfo::exists(dest) && !QFile::remove(dest)) {
+            QFile::remove(partial);
+            return false;
+        }
+
+        if (!QFile::rename(partial, dest)) {
+            QFile::remove(partial);
+            return false;
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Problem

`copyRecursively` writes directly to the destination name, and it never looks at what `write()` returned:

```cpp
out.write(buf.constData(), bytesRead);
processedBytes += bytesRead;
```

A full disk, a quota, or an I/O error therefore produces a file with the right name, the wrong length, and nothing to distinguish it from a complete one. The progress bar still reaches 100 per cent, because it counts what was read.

Opening the destination `WriteOnly` also truncates an existing file immediately, so a copy that fails part way through has destroyed the original as well as failed to produce the new one.

Thunar guards both halves with `misc-transfer-use-partial` and `misc-transfer-verify-file`.

## Change

The file is written to a partial name and renamed once all of it is through. Every `write` is compared against what was read, the final `flush` is checked, and so is the device error state after closing. Any of them removes the partial and reports failure.

The destination is only touched at the rename, so a failed copy leaves whatever was already there intact.

Permissions are carried across from the source. The hand-rolled loop never did this — `QFile::copy` would have — so until now every copied file came out with the default mode.

## Verified

Copying a 3 MB binary, a small file at mode 600 and a subdirectory: the binary compares equal to the source, the small file keeps mode 600, the subdirectory arrives, and no `.prism-partial` remains. The same after cancelling a 300 MB copy.

The write-failure path is reasoned rather than measured — I have no clean way to fill a disk here — but it is the same `abandon()` used by cancellation, which is exercised.
