### PR TITLE
feat: keep the icon size across sessions

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -34,6 +34,9 @@ ApplicationWindow {
     property bool pickerActive: typeof isPickerMode !== "undefined" ? isPickerMode : false
     property real zoomLevel: 80
 
+    Component.onCompleted: zoomLevel = AppController.iconZoomLevel
+    onZoomLevelChanged: AppController.iconZoomLevel = Math.round(zoomLevel)
+
     function getActiveDirectory() {
         if (!TabManager.currentTab) return "";
         return (TabManager.currentTab.isSplit && TabManager.currentTab.activePane === 1)

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -44,6 +44,7 @@ AppController::AppController(QObject* parent)
     m_defaultSortOrder = settings.value("preferences/defaultSortOrder", 0).toInt();
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
+    m_iconZoomLevel = qBound(48, settings.value("session/iconZoomLevel", 80).toInt(), 180);
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
     FileUtils::setDateFormat(m_dateFormat);
     m_thumbnailsEnabled = settings.value("preferences/thumbnailsEnabled", true).toBool();
@@ -119,6 +120,18 @@ void AppController::setConfirmPermanentDelete(bool confirm) {
         settings.setValue("session/confirmPermanentDelete", confirm);
         emit confirmPermanentDeleteChanged();
     }
+}
+
+void AppController::setIconZoomLevel(int level) {
+    const int clamped = qBound(48, level, 180);
+    if (m_iconZoomLevel == clamped)
+        return;
+
+    m_iconZoomLevel = clamped;
+
+    QSettings settings("prism", "prism");
+    settings.setValue("session/iconZoomLevel", clamped);
+    emit iconZoomLevelChanged();
 }
 
 void AppController::setDateFormat(int format) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -36,6 +36,7 @@ class AppController : public QObject {
     Q_PROPERTY(int defaultSortOrder READ defaultSortOrder WRITE setDefaultSortOrder NOTIFY defaultSortOrderChanged)
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
+    Q_PROPERTY(int iconZoomLevel READ iconZoomLevel WRITE setIconZoomLevel NOTIFY iconZoomLevelChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
     Q_PROPERTY(bool menuShowSecondaryEditor READ menuShowSecondaryEditor WRITE setMenuShowSecondaryEditor NOTIFY menuPreferencesChanged)
@@ -118,6 +119,9 @@ public:
     [[nodiscard]] int placesIconSize() const { return m_placesIconSize; }
     void setPlacesIconSize(int size);
 
+    [[nodiscard]] int iconZoomLevel() const { return m_iconZoomLevel; }
+    void setIconZoomLevel(int level);
+
     [[nodiscard]] QString selectedPath() const { return m_selectedPath; }
     void setSelectedPath(const QString& path);
 
@@ -172,6 +176,7 @@ signals:
     void defaultSortOrderChanged();
     void showDirsFirstChanged();
     void placesIconSizeChanged();
+    void iconZoomLevelChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
     void menuPreferencesChanged();
@@ -203,6 +208,7 @@ private:
     int m_defaultSortOrder = 0;
     bool m_showDirsFirst = true;
     int m_placesIconSize = 20;
+    int m_iconZoomLevel = 80;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;
     bool m_menuShowSecondaryEditor = true;


### PR DESCRIPTION
## Problem

`window.zoomLevel` is a plain QML property initialised to 80. The slider in the status bar and Ctrl with the wheel both change it, and nothing writes it anywhere, so every window opens at 80 again.

Requested by @iAmDeluded.

## Change

The level is stored in the settings and restored at startup, clamped to the 48–180 range the zoom shortcuts already enforce so a hand-edited value cannot produce an unusable window.

It is read once on completion rather than bound, because the shortcuts assign the property directly and a binding would be destroyed by the first zoom anyway.

## Note

This is one level shared by all three views. Thunar keeps three, `last-icon-view-zoom-level`, `last-compact-view-zoom-level` and `last-details-view-zoom-level`, since a comfortable grid size and a comfortable list size are not the same number. Prism has only ever had the one, so this persists what exists rather than changing the model; splitting it is a separate question.

## Verified

Setting 128 writes `iconZoomLevel=128` and a restart comes up at 128 rather than 80.
