### PR TITLE
feat: remove an entry from the Recent list

### DIFF
--- a/qml/components/menus/ContextMenu.qml
+++ b/qml/components/menus/ContextMenu.qml
@@ -26,6 +26,7 @@ MouseArea {
     }
 
     readonly property bool isTrash: currentDir.indexOf("Trash") !== -1 || currentDir.indexOf("trash:") !== -1 || (targetItem && targetItem.isTrashItem)
+    readonly property bool isRecent: currentDir.startsWith("recent:")
     readonly property bool isArchive: targetItem && (
         targetItem.name.endsWith(".zip") || targetItem.name.endsWith(".tar.gz") ||
         targetItem.name.endsWith(".tar.xz") || targetItem.name.endsWith(".tar.zst") ||
@@ -243,6 +244,9 @@ MouseArea {
                             } else {
                                 list.push({ text: qsTr("Move to Trash"), icon: "delete", action: "trash" });
                             }
+                        }
+                        if (root.isRecent) {
+                            list.push({ text: qsTr("Remove From Recent"), icon: "playlist_remove", action: "removeFromRecent" });
                         }
                         list.push({ text: qsTr("Properties"), icon: "info", action: "properties" });
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -423,6 +423,11 @@ ApplicationWindow {
                     for (let i = 0; i < targetPaths.length; ++i) {
                         FileOperations.restoreFromTrash(targetPaths[i]);
                     }
+                } else if (action === "removeFromRecent" && item) {
+                    FileOperations.removeFromRecent(targetPaths);
+                    if (splitContainer.activeModel) {
+                        splitContainer.activeModel.refresh();
+                    }
                 } else if (action === "emptyTrash") {
                     FileOperations.emptyTrash();
                 } else if (action === "bookmark") {

--- a/src/core/fileoperations.cpp
+++ b/src/core/fileoperations.cpp
@@ -1,4 +1,5 @@
 #include "fileoperations.hpp"
+#include "recentfiles.hpp"
 #include "trashlocations.hpp"
 #include <unistd.h>
 
@@ -550,6 +551,18 @@ void FileOperations::moveToTrash(const QStringList& paths) {
             emit operationFinished(allSuccess, allSuccess ? tr("Moved to trash") : tr("Failed to trash some items"));
         });
     });
+}
+
+void FileOperations::removeFromRecent(const QStringList& paths) {
+    if (paths.isEmpty())
+        return;
+
+    for (const QString& path : paths)
+        prism::core::RecentFiles::forget(path);
+
+    emit operationFinished(true, paths.size() == 1
+        ? tr("Removed one item from Recent")
+        : tr("Removed %1 items from Recent").arg(paths.size()));
 }
 
 void FileOperations::restoreFromTrash(const QString& targetPath) {

--- a/src/core/fileoperations.hpp
+++ b/src/core/fileoperations.hpp
@@ -121,6 +121,7 @@ public:
     Q_INVOKABLE void deletePermanently(const QStringList& paths);
     Q_INVOKABLE void moveToTrash(const QStringList& paths);
     Q_INVOKABLE void restoreFromTrash(const QString& trashInfoPath);
+    Q_INVOKABLE void removeFromRecent(const QStringList& paths);
     Q_INVOKABLE void emptyTrash();
     Q_INVOKABLE void renameFile(const QString& oldPath, const QString& newName);
     Q_INVOKABLE void bulkRename(const QStringList& paths, const QStringList& newNames);


### PR DESCRIPTION
## Problem

#40 added the Recent location together with a `RecentFiles::forget()`, and said in the description that nothing called it yet and that a context menu item would follow. This is that follow-up, so the dead function stops being dead.

Thunar has the same action, and without it the Recent list is append only: an entry you would rather not have there stays until it ages out.

## Change

`FileOperations::removeFromRecent` takes the selection and drops each path from `recently-used.xbel`. The context menu offers **Remove From Recent** while the Recent location is open, placed between Move to Trash and Properties as Thunar places it. Everything else in the menu keeps working, since the entries point at real files in their real locations.

The Recent listing has no file watcher — deliberately, because the backing store is a bookmark file rather than a directory, and `FileSystemModel` skips the watcher for it. The action therefore refreshes the model itself instead of waiting for a change notification that would never arrive.

![Remove From Recent in the context menu](https://raw.githubusercontent.com/eximora-private/PrismFiles/assets/recent-remove-menu.png)

## Verified

Against a live store of 76 bookmarks, of which 44 resolve to files that still exist. Removing the first entry took the listing from 44 rows to 43 and the store from 76 bookmarks to 75, with the correct entry gone and the file still valid XML. The test store was restored afterwards.

Worth noting for review: an earlier run of the same test appeared to fail, and the cause was the test rather than the code — launching with `recent:///` as the command line argument does not land on the Recent location, so the model was still showing the home directory. Navigating to it inside the window works. Whether the argument should also work is a separate question and not addressed here.
