### PR TITLE
fix: stop the runner game freezing when the dinosaur ducks

### DIFF
--- a/qml/components/dialogs/RunnerGameModal.qml
+++ b/qml/components/dialogs/RunnerGameModal.qml
@@ -259,7 +259,7 @@ Item {
                         let isDucking = RunnerGame.isDucking;
 
                         if (isDucking && !isCrashed) {
-                            let sx = (pFrame === 4) ? 2324 : 2206;
+                            let sx = (pFrame === 4) ? 2321 : 2203;
                             let dw = 59 * sf;
                             let dh = 29 * sf;
                             let oy = (RunnerGame.playerY + 18) * sf;


### PR DESCRIPTION
## Problem

Reported by @Evertiro: ducking in the runner game breaks it, and restarting the round does not help — only restarting Prism does.

The second ducking frame is read out of the sprite sheet at x 2324 with a width of 118, ending at 2442. The sheet is 2441 wide, so the source rectangle overhangs by exactly one pixel and Canvas raises

```
qrc:/qt/qml/prism/qml/components/dialogs/RunnerGameModal.qml:266: Error: drawImage(), index size error
```

once per frame for as long as the dinosaur is ducking. The throw aborts the paint callback, so the canvas stops updating. That is why a new round does not fix it — the round is fine, the canvas is the thing that stopped.

## Change

Measuring the sheet, the two ducking frames sit in a contiguous 236 pixel block from x 2203 to x 2438, which is exactly two 118 pixel cells. The cells therefore begin at **2203 and 2321**, not 2206 and 2324. Both now fall inside the sheet.

## Verified

Driving the game headlessly with `setDucking(true)` held through several seconds of play:

| | `index size error` count | state while ducking |
|---|---|---|
| before | one per rendered frame | canvas stops updating |
| after | 0 | keeps running, `playerFrame` reaches 4 |

`playerFrame` 4 is the frame that previously threw, so the run does exercise the case that was broken.

The two cells were also cut straight out of the sheet at the new offsets and inspected: both hold a complete ducking dinosaur with the legs in their two run positions, and neither is clipped.
