### PR TITLE
fix: scale the grid cell padding with the icon size

### DIFF
--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -12,8 +12,9 @@ Item {
     required property var activeTab
     property int paneIndex: 0
     property real zoomSize: 80
-    readonly property int labelLines: zoomSize < 64 ? 2 : (zoomSize < 80 ? 3 : 4)
+    readonly property int labelLines: Math.max(2, Math.min(4, Math.round(2 + (zoomSize - 48) / 60)))
     readonly property int labelHeight: Math.ceil(labelMetrics.height) * labelLines
+    readonly property int iconPadding: Math.max(6, Math.round(zoomSize * 0.1))
 
     FontMetrics {
         id: labelMetrics
@@ -171,7 +172,7 @@ Item {
 
         // Exact uniform cell dimensions
         cellWidth: Math.max(144, root.zoomSize + 48)
-        cellHeight: 16 + root.zoomSize + root.labelHeight
+        cellHeight: root.iconPadding * 2 + root.zoomSize + root.labelHeight
 
         clip: true
         focus: true
@@ -550,7 +551,7 @@ Item {
                     id: iconContainer
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: parent.top
-                    anchors.topMargin: 8
+                    anchors.topMargin: root.iconPadding
                     width: root.zoomSize
                     height: root.zoomSize
 


### PR DESCRIPTION
## Problem

Raised by @Evertiro, and confirmed by @dim-ghub as a bug: the padding under grid icons does not scale with the icon, so the middle of the zoom range reserves as much empty space as the icon occupies.

Two separate constants cause it.

```qml
readonly property int labelLines: zoomSize < 64 ? 2 : (zoomSize < 80 ? 3 : 4)
cellHeight: 16 + root.zoomSize + root.labelHeight
```

The label area steps to its maximum of four lines at a zoom of **80** and stays there for the rest of the 48–180 range, which is three quarters of the slider. The padding around the icon is a fixed 16 at every size. Evertiro's description — fine in the bottom third, fine in the top third, jumps to maximum in the middle and stays — is exactly this.

## Change

```qml
readonly property int labelLines: Math.max(2, Math.min(4, Math.round(2 + (zoomSize - 48) / 60)))
readonly property int iconPadding: Math.max(6, Math.round(zoomSize * 0.1))
```

| zoom | lines before | lines after | padding before | after |
|---|---|---|---|---|
| 48 | 2 | 2 | 8 | 6 |
| 80 | 4 | 3 | 8 | 8 |
| 120 | 4 | 3 | 8 | 12 |
| 140 | 4 | 4 | 8 | 14 |
| 180 | 4 | 4 | 8 | 18 |

Four lines now arrive in the top third, where the icon is large enough to carry them. The padding is a tenth of the icon, chosen so it is still exactly 8 at the default zoom of 80 and nothing moves for anyone who never touches the slider. The cell height stays uniform per zoom level, so selection highlights keep matching as @dim-ghub intended.

## Verified

Rendered at zoom 80 in a 620 by 560 view, before on the left and after on the right:

![Grid at zoom 80](https://raw.githubusercontent.com/eximora-private/PrismFiles/assets/grid-padding-80.png)

Three full rows with their labels, where before the second row was the last complete one and the third was cut off mid-label. Also rendered at 48 and 180 to confirm the ends of the range are unchanged in character.

## On long names

@dim-ghub noted the extra space is there for long file names, so here is the cost, before on the left and after on the right:

![Long names](https://raw.githubusercontent.com/eximora-private/PrismFiles/assets/grid-padding-longname.png)

One line less of a long name. Worth noting that the 71 character name is cut off either way — four lines does not show it, it only truncates slightly later. So the fourth line costs a row of items in every directory and does not actually solve the case it was reserved for. The real answer to that is showing the full name of the selected item somewhere, which is the separate thing @Evertiro described and I am doing next.
