### PR TITLE
feat: show the name of the selected item in the status bar

### DIFF
--- a/qml/components/statusbar/StatusBar.qml
+++ b/qml/components/statusbar/StatusBar.qml
@@ -11,6 +11,7 @@ StyledRect {
     required property var activeModel
     property var activeTab: null
     property int selectedCount: 0
+    property string selectedName: ""
     property string selectedSizeFormatted: ""
     property real zoomLevel: 80
     signal zoomChanged(real level)
@@ -37,10 +38,17 @@ StyledRect {
 
         // Selected summary
         StyledText {
+            Layout.maximumWidth: root.width * 0.6
             visible: root.selectedCount > 0
-            text: qsTr("•  %1 selected %2").arg(root.selectedCount).arg(root.selectedSizeFormatted.length > 0 ? `(${root.selectedSizeFormatted})` : "")
+            text: {
+                const size = root.selectedSizeFormatted.length > 0 ? ` (${root.selectedSizeFormatted})` : "";
+                if (root.selectedCount === 1 && root.selectedName.length > 0)
+                    return qsTr("•  %1%2").arg(root.selectedName).arg(size);
+                return qsTr("•  %1 selected%2").arg(root.selectedCount).arg(size);
+            }
             color: Colours.palette.m3primary
             font: Tokens.font.label.medium
+            elide: Text.ElideMiddle
         }
 
         StyledText {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -286,6 +286,13 @@ ApplicationWindow {
                         activeTab: TabManager.currentTab
                         zoomLevel: window.zoomLevel
                         selectedCount: splitContainer.selectedPaths.length > 0 ? splitContainer.selectedPaths.length : (contextMenu.targetItem ? 1 : 0)
+                        selectedName: {
+                            if (splitContainer.selectedPaths.length === 1)
+                                return splitContainer.selectedPaths[0].split("/").pop();
+                            if (splitContainer.selectedPaths.length === 0 && contextMenu.targetItem)
+                                return contextMenu.targetItem.name;
+                            return "";
+                        }
                         selectedSizeFormatted: contextMenu.targetItem ? (contextMenu.targetItem.isDir ? "" : contextMenu.targetItem.formattedSize) : ""
                         onZoomChanged: level => window.zoomLevel = level
                         onGitRequested: {


### PR DESCRIPTION
## Problem

From the discussion between @Evertiro and @dim-ghub about long file names: a grid cell can only show the first few lines of a name, so past a certain length the name is unreadable however much room the cell reserves. Evertiro's point was that there should be a way to see the whole thing once an item is selected; @dim-ghub pointed at the file dialog in Caelestia, which names the current item in a corner, and Evertiro confirmed that shape works.

Prism already has the place for it. The status bar carries the selection summary, and for a single item that summary is the string "1 selected", which says nothing you did not already know.

## Change

Selecting exactly one item names it:

```
4 items  •  Birds of Prey (and the Fantabulous Emancipation of One Harley Quinn).mkv  •  204.7 GB free
```

Selecting several is unchanged and still reads "4 selected". The name is capped at three fifths of the window width and elides in the middle rather than the end, so when the window is too narrow the beginning and the extension both survive — the two parts you actually navigate by.

## Verified

Top: a 71 character name at a 1150 wide window, shown in full. Middle: the same selection at 700 wide, elided in the middle with the extension intact. Bottom: four items selected, unchanged from before.

![Status bar](https://raw.githubusercontent.com/eximora-private/PrismFiles/assets/statusbar-selected-name.png)

## Relation to #55

#55 takes a line away from the grid label area, and this is the other half of that argument. The fourth line never showed a long name anyway — the 71 character name above is cut off with four lines just as it is with three — so the space is better spent on a row of items, with the full name available here once something is selected.
