### PR TITLE
fix: keep the drag selection anchored while the view scrolls

### DIFF
--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -623,8 +623,12 @@ Item {
         property real startY: 0
         property real currentX: 0
         property real currentY: 0
+        property real anchorContentX: 0
+        property real lastContentX: 0
         property bool isSelecting: false
         property bool wasSelecting: false
+
+        readonly property real anchorViewX: anchorContentX + gridView.x - gridView.contentX
 
         onPressed: mouse => {
             root.notifyFocus();
@@ -632,6 +636,8 @@ Item {
             startY = mouse.y;
             currentX = mouse.x;
             currentY = mouse.y;
+            anchorContentX = mouse.x - gridView.x + gridView.contentX;
+            lastContentX = gridView.contentX;
             isSelecting = false;
             wasSelecting = false;
         }
@@ -682,9 +688,10 @@ Item {
         }
 
         function updateRubberBandSelection() {
-            let rx = Math.min(startX, currentX) - gridView.x + gridView.contentX;
+            let cx = currentX - gridView.x + gridView.contentX;
+            let rx = Math.min(anchorContentX, cx);
             let ry = Math.min(startY, currentY) - gridView.y;
-            let rw = Math.abs(currentX - startX);
+            let rw = Math.abs(cx - anchorContentX);
             let rh = Math.abs(currentY - startY);
 
             let rows = Math.max(1, Math.floor(gridView.height / gridView.cellHeight));
@@ -707,15 +714,42 @@ Item {
             }
             root.selectedPaths = newlySelected;
         }
+
+        Timer {
+            running: dragSelectArea.isSelecting
+            interval: 16
+            repeat: true
+
+            onTriggered: {
+                const edge = 32;
+                const left = gridView.x;
+                const right = gridView.x + gridView.width;
+                let delta = 0;
+                if (dragSelectArea.currentX < left + edge)
+                    delta = -Math.min(28, (left + edge - dragSelectArea.currentX) / 2);
+                else if (dragSelectArea.currentX > right - edge)
+                    delta = Math.min(28, (dragSelectArea.currentX - (right - edge)) / 2);
+
+                if (delta !== 0) {
+                    const limit = Math.max(0, gridView.contentWidth - gridView.width);
+                    gridView.contentX = Math.max(0, Math.min(limit, gridView.contentX + delta));
+                }
+
+                if (gridView.contentX !== dragSelectArea.lastContentX) {
+                    dragSelectArea.lastContentX = gridView.contentX;
+                    dragSelectArea.updateRubberBandSelection();
+                }
+            }
+        }
     }
 
     // Rubber Band Visual Rectangle
     Rectangle {
         z: 999
         visible: dragSelectArea.isSelecting
-        x: Math.min(dragSelectArea.startX, dragSelectArea.currentX)
+        x: Math.min(dragSelectArea.anchorViewX, dragSelectArea.currentX)
         y: Math.min(dragSelectArea.startY, dragSelectArea.currentY)
-        width: Math.abs(dragSelectArea.currentX - dragSelectArea.startX)
+        width: Math.abs(dragSelectArea.currentX - dragSelectArea.anchorViewX)
         height: Math.abs(dragSelectArea.currentY - dragSelectArea.startY)
         color: Qt.alpha(Colours.palette.m3primary, 0.18)
         border.color: Colours.palette.m3primary

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -939,8 +939,12 @@ Item {
         property real startY: 0
         property real currentX: 0
         property real currentY: 0
+        property real anchorContentY: 0
+        property real lastContentY: 0
         property bool isSelecting: false
         property bool wasSelecting: false
+
+        readonly property real anchorViewY: anchorContentY + listView.y - listView.contentY
 
         onPressed: mouse => {
             root.notifyFocus();
@@ -948,6 +952,8 @@ Item {
             startY = mouse.y;
             currentX = mouse.x;
             currentY = mouse.y;
+            anchorContentY = mouse.y - listView.y + listView.contentY;
+            lastContentY = listView.contentY;
             isSelecting = false;
             wasSelecting = false;
         }
@@ -998,8 +1004,9 @@ Item {
         }
 
         function updateRubberBandSelection() {
-            let ry = Math.min(startY, currentY) - listView.y + listView.contentY;
-            let rh = Math.abs(currentY - startY);
+            let cy = currentY - listView.y + listView.contentY;
+            let ry = Math.min(anchorContentY, cy);
+            let rh = Math.abs(cy - anchorContentY);
 
             let newlySelected = [];
             let total = root.model ? root.model.count : 0;
@@ -1015,6 +1022,33 @@ Item {
             }
             root.selectedPaths = newlySelected;
         }
+
+        Timer {
+            running: dragSelectArea.isSelecting
+            interval: 16
+            repeat: true
+
+            onTriggered: {
+                const edge = 32;
+                const top = listView.y;
+                const bottom = listView.y + listView.height;
+                let delta = 0;
+                if (dragSelectArea.currentY < top + edge)
+                    delta = -Math.min(28, (top + edge - dragSelectArea.currentY) / 2);
+                else if (dragSelectArea.currentY > bottom - edge)
+                    delta = Math.min(28, (dragSelectArea.currentY - (bottom - edge)) / 2);
+
+                if (delta !== 0) {
+                    const limit = Math.max(0, listView.contentHeight - listView.height);
+                    listView.contentY = Math.max(0, Math.min(limit, listView.contentY + delta));
+                }
+
+                if (listView.contentY !== dragSelectArea.lastContentY) {
+                    dragSelectArea.lastContentY = listView.contentY;
+                    dragSelectArea.updateRubberBandSelection();
+                }
+            }
+        }
     }
 
     // Rubber Band Visual Rectangle
@@ -1022,9 +1056,9 @@ Item {
         z: 999
         visible: dragSelectArea.isSelecting
         x: Math.min(dragSelectArea.startX, dragSelectArea.currentX)
-        y: Math.min(dragSelectArea.startY, dragSelectArea.currentY)
+        y: Math.min(dragSelectArea.anchorViewY, dragSelectArea.currentY)
         width: Math.abs(dragSelectArea.currentX - dragSelectArea.startX)
-        height: Math.abs(dragSelectArea.currentY - dragSelectArea.startY)
+        height: Math.abs(dragSelectArea.currentY - dragSelectArea.anchorViewY)
         color: Qt.alpha(Colours.palette.m3primary, 0.18)
         border.color: Colours.palette.m3primary
         border.width: 1.5

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -666,8 +666,14 @@ Item {
         property real startY: 0
         property real currentX: 0
         property real currentY: 0
+        property real anchorContentX: 0
+        property real anchorContentY: 0
+        property real lastContentY: 0
         property bool isSelecting: false
         property bool wasSelecting: false
+
+        readonly property real anchorViewX: anchorContentX + view.x - view.contentX
+        readonly property real anchorViewY: anchorContentY + view.y - view.contentY
 
         onPressed: mouse => {
             root.notifyFocus();
@@ -675,6 +681,9 @@ Item {
             startY = mouse.y;
             currentX = mouse.x;
             currentY = mouse.y;
+            anchorContentX = mouse.x - view.x + view.contentX;
+            anchorContentY = mouse.y - view.y + view.contentY;
+            lastContentY = view.contentY;
             isSelecting = false;
             wasSelecting = false;
         }
@@ -725,10 +734,12 @@ Item {
         }
 
         function updateRubberBandSelection() {
-            let rx = Math.min(startX, currentX) - view.x + view.contentX;
-            let ry = Math.min(startY, currentY) - view.y + view.contentY;
-            let rw = Math.abs(currentX - startX);
-            let rh = Math.abs(currentY - startY);
+            let cx = currentX - view.x + view.contentX;
+            let cy = currentY - view.y + view.contentY;
+            let rx = Math.min(anchorContentX, cx);
+            let ry = Math.min(anchorContentY, cy);
+            let rw = Math.abs(cx - anchorContentX);
+            let rh = Math.abs(cy - anchorContentY);
 
             let cols = Math.max(1, Math.floor(view.width / view.cellWidth));
             let newlySelected = [];
@@ -750,16 +761,43 @@ Item {
             }
             root.selectedPaths = newlySelected;
         }
+
+        Timer {
+            running: dragSelectArea.isSelecting
+            interval: 16
+            repeat: true
+
+            onTriggered: {
+                const edge = 32;
+                const top = view.y;
+                const bottom = view.y + view.height;
+                let delta = 0;
+                if (dragSelectArea.currentY < top + edge)
+                    delta = -Math.min(28, (top + edge - dragSelectArea.currentY) / 2);
+                else if (dragSelectArea.currentY > bottom - edge)
+                    delta = Math.min(28, (dragSelectArea.currentY - (bottom - edge)) / 2);
+
+                if (delta !== 0) {
+                    const limit = Math.max(0, view.contentHeight - view.height);
+                    view.contentY = Math.max(0, Math.min(limit, view.contentY + delta));
+                }
+
+                if (view.contentY !== dragSelectArea.lastContentY) {
+                    dragSelectArea.lastContentY = view.contentY;
+                    dragSelectArea.updateRubberBandSelection();
+                }
+            }
+        }
     }
 
     // Rubber Band Visual Rectangle
     Rectangle {
         z: 999
         visible: dragSelectArea.isSelecting
-        x: Math.min(dragSelectArea.startX, dragSelectArea.currentX)
-        y: Math.min(dragSelectArea.startY, dragSelectArea.currentY)
-        width: Math.abs(dragSelectArea.currentX - dragSelectArea.startX)
-        height: Math.abs(dragSelectArea.currentY - dragSelectArea.startY)
+        x: Math.min(dragSelectArea.anchorViewX, dragSelectArea.currentX)
+        y: Math.min(dragSelectArea.anchorViewY, dragSelectArea.currentY)
+        width: Math.abs(dragSelectArea.currentX - dragSelectArea.anchorViewX)
+        height: Math.abs(dragSelectArea.currentY - dragSelectArea.anchorViewY)
         color: Qt.alpha(Colours.palette.m3primary, 0.18)
         border.color: Colours.palette.m3primary
         border.width: 1.5


### PR DESCRIPTION
## Problem

Two faults in rubber band selection, reported together.

**Dragging past the edge does not scroll.** There is no auto scroll at all, so a selection can never reach anything outside the viewport.

**Scrolling by hand during a drag moves the selection instead of extending it.** The rectangle is rebuilt each frame from the viewport coordinates of both corners:

```js
let ry = Math.min(startY, currentY) - view.y + view.contentY;
```

The anchor is re-projected through whatever `contentY` is current, so the whole rectangle slides with the content rather than staying where the drag began. Items that were selected drop out at the top as new ones come in at the bottom.

## Change

The anchor is recorded in content coordinates when the drag starts, and only the moving corner is projected each frame. The visual rectangle follows the same anchor, so it stays glued to the content underneath as the view scrolls.

A timer runs for the duration of the drag. It scrolls the view when the pointer is within 32 pixels of an edge, and recomputes the selection whenever the content has actually moved — which also covers scrolling by wheel, so both ways of scrolling mid-drag now behave the same.

All three views carried the same code. `FileCompactView` scrolls horizontally rather than vertically, so it gets the same treatment on the other axis.

## Verified

Driving a fixed drag rectangle over a directory of 60 files, then scrolling 300 pixels without moving the pointer:

| | selected before the scroll | after | of the original still selected |
|---|---|---|---|
| before | 8 | 8 | **4** |
| after | 8 | 12 | **8** |

Before, the count stays the same because the rectangle slid: four items left the selection at the top while four joined at the bottom. After, the rectangle grows from a fixed anchor, so the original eight are all still in and four more have joined.
