### PR TITLE
fix: stop the file dialog name panel running off the edge

### DIFF
--- a/qml/components/filedialog/CurrentItem.qml
+++ b/qml/components/filedialog/CurrentItem.qml
@@ -7,7 +7,9 @@ Item {
 
     property var currentItem: null
 
-    implicitWidth: content.implicitWidth + Tokens.padding.medium + content.anchors.rightMargin
+    readonly property real availableWidth: parent ? parent.width - Tokens.padding.extraSmall * 2 : 0
+
+    implicitWidth: Math.min(availableWidth, content.implicitWidth + Tokens.padding.medium + content.anchors.rightMargin)
     implicitHeight: currentItem ? content.implicitHeight + Tokens.padding.medium + content.anchors.bottomMargin : 0
 
     Shape {
@@ -76,6 +78,9 @@ Item {
             anchors.bottom: parent.bottom
             anchors.rightMargin: Tokens.padding.medium - Tokens.padding.extraSmall
             anchors.bottomMargin: Tokens.padding.medium - Tokens.padding.extraSmall
+
+            width: Math.min(implicitWidth, root.availableWidth - Tokens.padding.medium - anchors.rightMargin)
+            elide: Text.ElideMiddle
 
             Connections {
                 function onCurrentItemChanged() {


### PR DESCRIPTION
## Problem

Reported by @Evertiro: picking a file with a very long name leaves the little panel that names the current item running off the left side of the dialog.

`CurrentItem` sizes itself from the unwrapped width of its own label:

```qml
implicitWidth: content.implicitWidth + Tokens.padding.medium + content.anchors.rightMargin
```

Nothing bounds that, and the panel is anchored to the bottom right corner of the listing, so a long name grows it leftwards past the dialog and off the window.

## Change

The panel is capped at the width of its parent, and the label elides in the middle rather than the end, so the beginning of the name and the extension both survive when there is not room for the whole thing.

## Verified

With a 78 character name, in a dialog whose listing is 330 wide:

| | panel width | available | overflows |
|---|---|---|---|
| before | 766 | 322 | yes, by 444 |
| after | 322 | 322 | no |

The label's natural width is 746 in both cases; before it was rendered at that width, after it renders at 302 and elides.

Worth noting for @dim-ghub: `components/filedialog/CurrentItem.qml` in Caelestia is the same file with the same unbounded `implicitWidth`, so the shell's own file dialog has this too. This change applies cleanly there.
