### PR TITLE
fix: keep an attached menu aligned to the item it hangs off

### DIFF
--- a/qml/components/controls/Menu.qml
+++ b/qml/components/controls/Menu.qml
@@ -69,7 +69,7 @@ MouseArea {
         let sync = 0;
         let item = attachTo;
         while (item && item !== root) {
-            sync += item.x + item.y + item.width + item.height;
+            sync += item.x + item.y + item.width + item.height + item.scale + item.rotation;
             item = item.parent;
         }
         return sync;


### PR DESCRIPTION
## Problem

Reported by @dim-ghub: the menu on a split button does not line up with the button it belongs to.

`Menu` places itself with `mapToItem`, which is not reactive. To work around that it keeps a running sum of ancestor geometry and reads it inside the `x` and `y` bindings for no reason other than to force re-evaluation:

```qml
readonly property real transformSync: {
    let sync = 0;
    let item = attachTo;
    while (item && item !== root) {
        sync += item.x + item.y + item.width + item.height;
        item = item.parent;
    }
    return sync;
}
```

The sum covers position and size and leaves out **scale**. A modal opens with a scale animation, and scaling an ancestor changes what `mapToItem` returns without changing any of the four summed values. So the position is computed part way through the open animation and never corrected once it settles.

That also explains why it is easy to miss: whether it looks wrong depends on where the animation happened to be, so it can look fine on one machine and clearly off on another.

## Change

`scale` and `rotation` join the sum, so the bindings re-evaluate when an ancestor is transformed and not only when one is moved or resized.

## Verified

Distance between the right edge of the menu and the right edge of the split button it attaches to, on Thumbnail Size Limit, six runs of each:

| | run 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| before | -9 | -9 | -9 | -9 | -9 | -9 |
| after | 0 | 0 | 0 | 0 | 0 | 0 |

Nine pixels short of the button before, flush after, and consistent rather than depending on timing.

Worth noting the same `transformSync` sits in Caelestia's `Menu.qml` and has the same omission, so any attached menu inside a scaling ancestor there drifts the same way.
