### PR TITLE
fix: stop the last line of a grid label touching the card edge

### DIFF
--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -172,7 +172,7 @@ Item {
 
         // Exact uniform cell dimensions
         cellWidth: Math.max(144, root.zoomSize + 48)
-        cellHeight: root.iconPadding * 2 + root.zoomSize + root.labelHeight
+        cellHeight: root.iconPadding * 2 + root.zoomSize + root.labelHeight + 12
 
         clip: true
         focus: true
@@ -616,11 +616,13 @@ Item {
                     id: name
 
                     anchors.top: iconContainer.bottom
-                    anchors.topMargin: 4
                     anchors.left: parent.left
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
-                    anchors.margins: 4
+                    anchors.topMargin: 4
+                    anchors.leftMargin: 4
+                    anchors.rightMargin: 4
+                    anchors.bottomMargin: root.iconPadding
 
                     text: delegateContainer.modelData ? delegateContainer.modelData.name : ""
                     color: delegateContainer.isSelected ? Colours.palette.m3onSecondaryContainer : Colours.palette.m3onSurface


### PR DESCRIPTION
## Problem

Reported by @Evertiro: the last line of a long name in the grid touches the edge of the selection card.

This is a regression from #55. That change set

```qml
cellHeight: root.iconPadding * 2 + root.zoomSize + root.labelHeight
```

which leaves nothing for two insets that were already in the delegate: `itemCard` is eight pixels smaller than the cell, and the label sits four pixels below the icon. The label is anchored top *and* bottom, so instead of overflowing it was squeezed — and the card has `clip: true`, so the descenders of the last line were cut off.

How short the card was, in pixels, by zoom level:

| zoom | 48 | 80 | 110 | 140 | 180 |
|---|---|---|---|---|---|
| shortfall | 10 | 8 | 5 | 2 | -2 |

Only the very top of the range had room. That is why it reads as fine at large icons and wrong everywhere else, and why I did not catch it when I checked #55 at 48 and 180.

## Change

The cell height accounts for both insets, and the gap below the label is `iconPadding` rather than a flat four, so the card has the same breathing room under the text as it has above the icon. The budget now balances exactly:

| zoom | 48 | 80 | 110 | 140 | 180 |
|---|---|---|---|---|---|
| card height minus content | 0 | 0 | 0 | 0 | 0 |

## Verified

Evertiro's folder name at zoom 110, before on the left, after on the right:

![Grid label](https://raw.githubusercontent.com/eximora-private/PrismFiles/assets/grid-label-bottom.png)
