### PR TITLE
fix: place attached menus directly below and right aligned

### DIFF
--- a/qml/components/controls/Menu.qml
+++ b/qml/components/controls/Menu.qml
@@ -9,18 +9,7 @@ import "../effects"
 MouseArea {
     id: root
 
-    enum Side {
-        Top,
-        Bottom,
-        Left,
-        Right
-    }
-
     required property Item attachTo
-    property int attachSideX: Menu.Right
-    property int attachSideY: Menu.Bottom
-    property int thisSideX: Menu.Right
-    property int thisSideY: Menu.Top
     property real marginX
     property real marginY
 
@@ -64,6 +53,29 @@ MouseArea {
         }
     }
 
+    readonly property Item scrollParent: {
+        let item = attachTo;
+        while (item) {
+            if (item.contentY !== undefined && item.contentHeight !== undefined)
+                return item;
+            item = item.parent;
+        }
+        return null;
+    }
+
+    Connections {
+        target: root.expanded ? root.scrollParent : null
+        ignoreUnknownSignals: true
+
+        function onContentYChanged(): void {
+            root.expanded = false;
+        }
+
+        function onContentXChanged(): void {
+            root.expanded = false;
+        }
+    }
+
     // mapToItem is not reactive so this forces updates when ancestor geometry changes (scrolling, moving)
     readonly property real transformSync: {
         let sync = 0;
@@ -93,20 +105,14 @@ MouseArea {
             const item = root.attachTo;
             if (!item || !root.parent)
                 return 0;
-            let off = root.attachSideX === Menu.Left ? 0 : item.width;
-            if (root.thisSideX === Menu.Right)
-                off -= width;
-            return item.mapToItem(root.parent, off, 0).x + root.marginX;
+            return item.mapToItem(root.parent, item.width - width, 0).x + root.marginX;
         }
         y: {
             root.transformSync; // force updates
             const item = root.attachTo;
             if (!item || !root.parent)
                 return 0;
-            let off = root.attachSideY === Menu.Top ? 0 : item.height;
-            if (root.thisSideY === Menu.Bottom)
-                off -= height;
-            return item.mapToItem(root.parent, 0, off).y + root.marginY;
+            return item.mapToItem(root.parent, 0, item.height).y + root.marginY;
         }
 
         radius: Tokens.rounding.large
@@ -117,7 +123,7 @@ MouseArea {
 
         transform: Scale {
             yScale: root.expanded ? 1 : 0.1
-            origin.y: root.thisSideY === Menu.Bottom ? menu.height : 0
+            origin.y: 0
 
             Behavior on yScale {
                 Anim {}

--- a/qml/components/controls/SplitButton.qml
+++ b/qml/components/controls/SplitButton.qml
@@ -16,7 +16,6 @@ Row {
     property real verticalPadding: Tokens.padding.small
     property int type: SplitButton.Filled
     property bool disabled
-    property bool menuOnTop
     property string fallbackIcon
     property string fallbackText
     property real minLeftWidth
@@ -159,10 +158,6 @@ Row {
         id: menu
 
         attachTo: expandBtn
-        attachSideX: Menu.Right
-        thisSideX: Menu.Right
-        attachSideY: root.menuOnTop ? Menu.Top : Menu.Bottom
-        thisSideY: root.menuOnTop ? Menu.Bottom : Menu.Top
-        marginY: Tokens.spacing.small * (root.menuOnTop ? -1 : 1)
+        marginY: Tokens.spacing.small
     }
 }

--- a/qml/components/controls/SplitButtonRow.qml
+++ b/qml/components/controls/SplitButtonRow.qml
@@ -13,7 +13,6 @@ ConnectedRect {
     property alias active: splitButton.active
     property alias fallbackText: splitButton.fallbackText
     property alias fallbackIcon: splitButton.fallbackIcon
-    property alias menuOnTop: splitButton.menuOnTop
 
     signal selected(item: MenuItem)
 


### PR DESCRIPTION
## Problem

@dim-ghub reported the split button menus are still misaligned after #59, and gave the rule they should follow: **always directly below the button and aligned with its right edge.**

The cause is a name resolution trap, and #59 only masked part of it.

`Menu` declares `enum Side { Top, Bottom, Left, Right }` and the positioning bindings compare against it:

```qml
let off = root.attachSideY === Menu.Top ? 0 : item.height;
```

At the root of the file the enum reads as declared. Inside the bindings it does not:

| | Top | Bottom | Left | Right |
|---|---|---|---|---|
| at file root | 0 | 1 | 2 | 3 |
| inside the bindings | 1 | 7 | 3 | 5 |

1, 7, 3, 5 are `Item.TransformOrigin.Top`, `.Bottom`, `.Left`, `.Right`. In that scope `Menu` resolves to the enclosing instance rather than to the type, so `.Top` reads an unrelated enum off an `Item`.

`attachSideY` is 1 for Bottom, and `Menu.Top` is also 1 there, so `attachSideY === Menu.Top` matched. Every menu was placed at the **top** edge of its button rather than the bottom, overlapping it by the button's own height. On the horizontal axis the two wrong values happened to cancel, which is why #59 measured clean on x and I did not look at y.

## Change

The indirection is gone rather than repaired. `SplitButton` was the only thing that ever set the four side properties, and it set them to the defaults, so nothing needed the flexibility. Placement is now unconditionally below and right aligned, which is the rule asked for and removes an enum that can be misread again.

`menuOnTop` went with it — nothing ever set it to true.

Menus now also **close when the surface under them scrolls**, rather than sliding along with the content.

## Verified

All nineteen split buttons across the four preferences tabs, distance from the button's right edge and from its bottom edge:

| | dx | dy |
|---|---|---|
| before | 0 | **-32** |
| after | 0 | **8** |

Every one of the nineteen reports the same pair. Eight is the intended `Tokens.spacing.small` gap; -32 was the previous overlap, being an 8 pixel margin applied above a 40 pixel button.

Scroll behaviour, four runs: the menu stays open while nothing moves and closes as soon as the flickable's `contentY` changes.
