### PR TITLE
feat(metadata): add media container and photo EXIF metadata extractio…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ qt_add_executable(atlas_app
     src/core/drivemanager.cpp
     src/core/filemetadata.hpp
     src/core/filemetadata.cpp
+    src/core/exifreader.hpp
+    src/core/exifreader.cpp
     src/core/mimeservice.hpp
     src/core/mimeservice.cpp
     src/core/gitmanager.hpp
@@ -200,6 +202,16 @@ target_link_libraries(atlas_app PRIVATE
     Qt6::Multimedia
     Qt6::Network
 )
+
+# Optional EXIF metadata support via Exiv2; degrades gracefully when absent
+find_package(exiv2 QUIET)
+if(exiv2_FOUND)
+    message(STATUS "Exiv2 found - EXIF metadata support enabled")
+    target_link_libraries(atlas_app PRIVATE exiv2lib)
+    target_compile_definitions(atlas_app PRIVATE ATLAS_HAVE_EXIV2 PRISM_HAVE_EXIV2)
+else()
+    message(STATUS "Exiv2 not found - building without EXIF metadata support")
+endif()
 
 # Native XDG Desktop Portal FileChooser daemon for Atlas
 qt_add_executable(xdg_desktop_portal_astra_atlas

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Atlas is a fast, lightweight Material Design 3 file manager and file picker buil
 - `xdg-desktop-portal`: desktop portal integration for system-wide file chooser dialogs
 - `xdg-utils`: default application launching via `xdg-open`
 - `git`: inline repository status, branch tracking, and Git modal operations
+- `exiv2` (development package at build time): EXIF metadata display for photos in the preview panel and properties dialog; builds without it when absent
 - `caelestia-cli`: dynamic color palette and accent syncing with Caelestia
 - `papirus-icon-theme` and `papirus-folders`: dynamic folder color and system icon theme integration
 - Archive tools: `p7zip`, `tar`, `gzip`, `bzip2`, `xz`, `zip`, `unzip` for archive extraction and compression

--- a/qml/components/StateLayer.qml
+++ b/qml/components/StateLayer.qml
@@ -116,6 +116,7 @@ MouseArea {
         anchors.fill: parent
         opacity: 0
         preferredRendererType: Shape.CurveRenderer
+        visible: opacity > 0.001
 
         ShapePath {
             strokeWidth: 0

--- a/qml/components/controls/ButtonRowItem.qml
+++ b/qml/components/controls/ButtonRowItem.qml
@@ -80,7 +80,7 @@ StyledRect {
 
     color: root.checked
         ? root.activeColor
-        : (itemHover.containsMouse ? root.hoverColor : root.inactiveColor)
+        : (stateLayer.containsMouse ? root.hoverColor : root.inactiveColor)
 
     Behavior on color {
         CAnim {
@@ -90,6 +90,7 @@ StyledRect {
     }
 
     StateLayer {
+        id: stateLayer
         anchors.fill: parent
         topLeftRadius: parent.topLeftRadius
         topRightRadius: parent.topRightRadius
@@ -101,14 +102,19 @@ StyledRect {
     }
 
     RowLayout {
-        anchors.centerIn: parent
+        anchors.fill: parent
+        anchors.leftMargin: Tokens.padding.small
+        anchors.rightMargin: Tokens.padding.small
         spacing: 6
+
+        Item { Layout.fillWidth: true }
 
         MaterialIcon {
             visible: root.activeIcon.length > 0
             text: root.activeIcon
             fontStyle: Tokens.font.icon.small
             color: root.checked ? root.activeIconColor : root.inactiveIconColor
+            Layout.alignment: Qt.AlignVCenter
 
             Behavior on color {
                 CAnim {
@@ -124,6 +130,8 @@ StyledRect {
             font: Tokens.font.body.small
             color: root.checked ? root.activeOnColor : root.inactiveOnColor
             elide: Text.ElideRight
+            Layout.maximumWidth: root.width - (root.icon.length > 0 ? 36 : 16)
+            Layout.alignment: Qt.AlignVCenter
 
             Behavior on color {
                 CAnim {
@@ -132,13 +140,7 @@ StyledRect {
                 }
             }
         }
-    }
 
-    MouseArea {
-        id: itemHover
-        anchors.fill: parent
-        hoverEnabled: !root.disabled
-        cursorShape: root.disabled ? Qt.ArrowCursor : Qt.PointingHandCursor
-        onClicked: if (!root.disabled) root.clicked()
+        Item { Layout.fillWidth: true }
     }
 }

--- a/qml/components/dialogs/PropertiesModal.qml
+++ b/qml/components/dialogs/PropertiesModal.qml
@@ -109,13 +109,17 @@ MouseArea {
             // Tab Bar Switcher
             ButtonRow {
                 Layout.fillWidth: true
+                Layout.preferredHeight: 38
+                implicitHeight: 38
                 model: {
                     let tabs = [
                         { tab: 0, label: qsTr("General"), icon: "info" },
                         { tab: 1, label: qsTr("Permissions"), icon: "lock" }
                     ];
                     if (!meta.isDir) {
-                        tabs.push({ tab: 2, label: qsTr("Checksums"), icon: "tag" });
+                        tabs.push({ tab: 2, label: qsTr("Checksums"), icon: "fingerprint" });
+                        if (meta.hasMediaDetails)
+                            tabs.push({ tab: 3, label: qsTr("Details"), icon: "perm_media" });
                     }
                     return tabs;
                 }
@@ -129,6 +133,14 @@ MouseArea {
                 }
             }
 
+            Connections {
+                target: meta
+                function onMediaDetailsChanged() {
+                    if (root.currentTab === 3 && !meta.hasMediaDetails)
+                        root.currentTab = 0;
+                }
+            }
+
             // Tab 0: General
             ColumnLayout {
                 visible: root.currentTab === 0
@@ -138,23 +150,27 @@ MouseArea {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Type:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    spacing: 12
+                    StyledText { Layout.preferredWidth: 120; text: qsTr("Type:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.mimeDescription || (meta.isDir ? qsTr("Folder") : meta.mimeType); font: Tokens.font.body.medium; color: Colours.palette.m3onSurface; elide: Text.ElideRight }
                 }
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Location:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    spacing: 12
+                    StyledText { Layout.preferredWidth: 120; text: qsTr("Location:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.path; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; elide: Text.ElideMiddle }
                 }
                 RowLayout {
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: meta.isDir ? qsTr("Contents:") : qsTr("Size:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    spacing: 12
+                    StyledText { Layout.preferredWidth: 120; text: meta.isDir ? qsTr("Contents:") : qsTr("Size:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.isDir ? qsTr("%1 items").arg(meta.itemCount) : meta.formattedSize; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface; elide: Text.ElideRight }
                 }
                 RowLayout {
                     visible: meta.imageDimensions.length > 0
                     Layout.fillWidth: true
-                    StyledText { Layout.preferredWidth: 110; text: qsTr("Dimensions:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    spacing: 12
+                    StyledText { Layout.preferredWidth: 120; text: qsTr("Dimensions:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.imageDimensions; font: Tokens.font.body.medium; color: Colours.palette.m3onSurface; elide: Text.ElideRight }
                 }
 
@@ -162,30 +178,33 @@ MouseArea {
 
                 RowLayout {
                     Layout.fillWidth: true
+                    spacing: 12
                     Layout.alignment: Qt.AlignTop
-                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Created:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.preferredWidth: 120; Layout.alignment: Qt.AlignTop; text: qsTr("Created:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.formattedCreated; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
                 RowLayout {
                     Layout.fillWidth: true
+                    spacing: 12
                     Layout.alignment: Qt.AlignTop
-                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Modified:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.preferredWidth: 120; Layout.alignment: Qt.AlignTop; text: qsTr("Modified:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.formattedModified; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
                 RowLayout {
                     Layout.fillWidth: true
+                    spacing: 12
                     Layout.alignment: Qt.AlignTop
-                    StyledText { Layout.preferredWidth: 110; Layout.alignment: Qt.AlignTop; text: qsTr("Accessed:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
+                    StyledText { Layout.preferredWidth: 120; Layout.alignment: Qt.AlignTop; text: qsTr("Accessed:"); font: Tokens.font.label.medium; color: Colours.palette.m3onSurfaceVariant }
                     StyledText { Layout.fillWidth: true; text: meta.formattedAccessed; font: Tokens.font.body.small; color: Colours.palette.m3onSurface; wrapMode: Text.WordWrap }
                 }
 
                 RowLayout {
                     visible: !meta.isDir
                     Layout.fillWidth: true
-                    spacing: Tokens.spacing.small
+                    spacing: 12
 
                     StyledText {
-                        Layout.preferredWidth: 110
+                        Layout.preferredWidth: 120
                         text: qsTr("Open With:")
                         font: Tokens.font.label.medium
                         color: Colours.palette.m3onSurfaceVariant
@@ -479,6 +498,158 @@ MouseArea {
                 }
 
                 Item { Layout.fillHeight: true }
+            }
+
+            // Tab 3: Media Metadata (EXIF / container tags)
+            ColumnLayout {
+                visible: root.currentTab === 3 && meta.hasMediaDetails
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 8
+
+                StyledText {
+                    text: meta.isVideo ? qsTr("Container Metadata") : (meta.isAudio ? qsTr("Audio Tags") : qsTr("EXIF Metadata"))
+                    font: Tokens.font.title.small
+                    color: Colours.palette.m3onSurface
+                }
+
+                Flickable {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    contentHeight: detailsCol.implicitHeight
+                    clip: true
+                    boundsBehavior: Flickable.StopAtBounds
+
+                    ScrollBar.vertical: StyledScrollBar {
+                        flickable: parent
+                    }
+
+                    ColumnLayout {
+                        id: detailsCol
+                        width: parent.width
+                        spacing: 8
+
+                        Repeater {
+                            model: meta.mediaDetails
+
+                            RowLayout {
+                                id: detailRow
+                                required property var modelData
+                                readonly property bool isCommentRow: detailRow.modelData.label === "Comment" && meta.isImage
+                                property bool isEditing: false
+
+                                Layout.fillWidth: true
+                                spacing: 12
+
+                                StyledText {
+                                    Layout.preferredWidth: 130
+                                    text: detailRow.modelData.label + ":"
+                                    font: Tokens.font.label.medium
+                                    color: Colours.palette.m3onSurfaceVariant
+                                    Layout.alignment: Qt.AlignVCenter
+                                }
+
+                                // Standard view
+                                RowLayout {
+                                    visible: !detailRow.isEditing
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: 28
+                                    Layout.alignment: Qt.AlignVCenter
+                                    spacing: 8
+
+                                    StyledText {
+                                        Layout.fillWidth: true
+                                        Layout.alignment: Qt.AlignVCenter
+                                        text: {
+                                            if (detailRow.modelData.value && detailRow.modelData.value.length > 0)
+                                                return detailRow.modelData.value;
+                                            return detailRow.isCommentRow ? qsTr("(No comment)") : "";
+                                        }
+                                        font: Tokens.font.body.medium
+                                        color: (detailRow.isCommentRow && (!detailRow.modelData.value || detailRow.modelData.value.length === 0))
+                                            ? Colours.palette.m3outline
+                                            : Colours.palette.m3onSurface
+                                        wrapMode: Text.Wrap
+                                    }
+
+                                    IconButton {
+                                        visible: detailRow.isCommentRow
+                                        icon: "edit"
+                                        type: ButtonBase.Standard
+                                        implicitWidth: 26
+                                        implicitHeight: 26
+                                        Layout.alignment: Qt.AlignVCenter
+                                        onClicked: {
+                                            commentInput.text = detailRow.modelData.value || "";
+                                            detailRow.isEditing = true;
+                                            commentInput.forceActiveFocus();
+                                        }
+                                    }
+                                }
+
+                                // Editable view
+                                RowLayout {
+                                    visible: detailRow.isEditing
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: 28
+                                    Layout.alignment: Qt.AlignVCenter
+                                    spacing: 6
+
+                                    StyledRect {
+                                        Layout.fillWidth: true
+                                        implicitHeight: 28
+                                        radius: Tokens.rounding.extraSmall
+                                        color: Colours.palette.m3surfaceContainerHighest
+                                        border.color: commentInput.activeFocus ? Colours.palette.m3primary : Qt.alpha(Colours.palette.m3outlineVariant, 0.5)
+                                        border.width: commentInput.activeFocus ? 2 : 1
+                                        clip: true
+
+                                        TextInput {
+                                            id: commentInput
+                                            anchors.fill: parent
+                                            anchors.leftMargin: 8
+                                            anchors.rightMargin: 8
+                                            color: Colours.palette.m3onSurface
+                                            selectionColor: Colours.palette.m3primaryContainer
+                                            selectedTextColor: Colours.palette.m3onPrimaryContainer
+                                            font: Tokens.font.body.medium
+                                            selectByMouse: true
+                                            verticalAlignment: TextInput.AlignVCenter
+                                            onAccepted: {
+                                                meta.setComment(commentInput.text.trim());
+                                                detailRow.isEditing = false;
+                                            }
+                                            Keys.onEscapePressed: detailRow.isEditing = false
+                                        }
+                                    }
+
+                                    IconButton {
+                                        icon: "check"
+                                        type: ButtonBase.Filled
+                                        implicitWidth: 26
+                                        implicitHeight: 26
+                                        Layout.alignment: Qt.AlignVCenter
+                                        onClicked: {
+                                            meta.setComment(commentInput.text.trim());
+                                            detailRow.isEditing = false;
+                                        }
+                                    }
+
+                                    IconButton {
+                                        icon: "close"
+                                        type: ButtonBase.Standard
+                                        implicitWidth: 26
+                                        implicitHeight: 26
+                                        Layout.alignment: Qt.AlignVCenter
+                                        onClicked: {
+                                            detailRow.isEditing = false;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             // Bottom Close Button

--- a/qml/components/panels/PreviewPanel.qml
+++ b/qml/components/panels/PreviewPanel.qml
@@ -28,6 +28,35 @@ StyledRect {
         path: root.targetPath
     }
 
+    component InfoRow: ColumnLayout {
+        id: infoRow
+
+        required property var modelData
+        readonly property string rowLabel: (infoRow.modelData.label ?? "").toString()
+        readonly property string rowValue: {
+            const v = infoRow.modelData.value;
+            return v === undefined || v === null ? "" : String(v);
+        }
+
+        Layout.fillWidth: true
+        spacing: 2
+        visible: infoRow.modelData.visible !== false && infoRow.rowValue.length > 0
+
+        StyledText {
+            text: infoRow.rowLabel.endsWith(":") ? infoRow.rowLabel : infoRow.rowLabel + ":"
+            color: Colours.palette.m3onSurfaceVariant
+            font: Tokens.font.label.medium
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            text: infoRow.rowValue
+            color: Colours.palette.m3onSurface
+            font: Tokens.font.body.small
+            wrapMode: Text.Wrap
+        }
+    }
+
     Flickable {
         anchors.fill: parent
         anchors.margins: Tokens.padding.medium
@@ -67,28 +96,32 @@ StyledRect {
             // Image / Video / Icon Preview
             StyledRect {
                 Layout.fillWidth: true
-                implicitHeight: 180
+                implicitHeight: 200
                 radius: Tokens.rounding.medium
                 color: previewCardHover.containsMouse ? Colours.palette.m3surfaceContainerHighest : Colours.tPalette.m3surfaceContainerHigh
                 clip: true
 
-                // Image Preview
+                // Image & Video Preview (Full size)
                 Image {
                     anchors.fill: parent
                     anchors.margins: Tokens.padding.small
                     fillMode: Image.PreserveAspectFit
                     cache: false
-                    source: meta.isImage ? ("image://thumb/" + meta.path + "?t=" + (meta.lastModified ? meta.lastModified.getTime() : 0)) : ""
-                    visible: meta.isImage
+                    source: (meta.isImage || meta.isVideo) && meta.path.length > 0
+                        ? ("image://thumb/" + meta.path + "?t=" + meta.lastModifiedMs)
+                        : ""
+                    visible: meta.isImage || meta.isVideo
                     asynchronous: true
+                    mipmap: true
+                    smooth: true
                 }
 
-                // Video Thumbnail or Generic Icon Preview
+                // Generic File / Folder Icon Preview (when not media)
                 CachingIconImage {
                     anchors.centerIn: parent
                     implicitSize: 72
-                    visible: !meta.isImage
-                    source: meta.isVideo ? ("image://thumb/" + meta.path + "?t=" + (meta.lastModified ? meta.lastModified.getTime() : 0)) : FileUtils.iconForFile(meta.name, meta.isDir, meta.mimeType)
+                    visible: !meta.isImage && !meta.isVideo
+                    source: FileUtils.iconForFile(meta.name, meta.isDir, meta.mimeType)
                 }
 
                 // Video Badge Overlay
@@ -164,35 +197,26 @@ StyledRect {
             // Key-Value Metadata List
             Repeater {
                 model: [
-                    { label: qsTr("Size:"), value: meta.isDir ? `${meta.itemCount} items` : meta.formattedSize },
-                    { label: qsTr("Type:"), value: meta.mimeDescription.length > 0 ? meta.mimeDescription : (meta.isDir ? "Folder" : "File") },
-                    { label: qsTr("Dimensions:"), value: meta.imageDimensions, visible: meta.isImage && meta.imageDimensions.length > 0 },
-                    { label: qsTr("Modified:"), value: meta.formattedModified },
-                    { label: qsTr("Created:"), value: meta.formattedCreated },
-                    { label: qsTr("Accessed:"), value: meta.formattedAccessed },
-                    { label: qsTr("Permissions:"), value: meta.permissions },
-                    { label: qsTr("Owner:"), value: `${meta.owner} : ${meta.group}` }
+                    { label: qsTr("Size"), value: meta.isDir ? `${meta.itemCount} items` : meta.formattedSize },
+                    { label: qsTr("Type"), value: meta.mimeDescription.length > 0 ? meta.mimeDescription : (meta.isDir ? "Folder" : "File") },
+                    { label: qsTr("Dimensions"), value: meta.imageDimensions, visible: meta.isImage && meta.imageDimensions.length > 0 },
+                    { label: qsTr("Resolution"), value: meta.videoDimensions, visible: meta.isVideo && meta.videoDimensions.length > 0 },
+                    { label: qsTr("Duration"), value: meta.durationFormatted, visible: (meta.isVideo || meta.isAudio) && meta.durationFormatted.length > 0 },
+                    { label: qsTr("Modified"), value: meta.formattedModified },
+                    { label: qsTr("Created"), value: meta.formattedCreated },
+                    { label: qsTr("Accessed"), value: meta.formattedAccessed },
+                    { label: qsTr("Permissions"), value: meta.permissions },
+                    { label: qsTr("Owner"), value: `${meta.owner} : ${meta.group}` }
                 ]
 
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 2
-                    visible: modelData.visible !== false && modelData.value && String(modelData.value).length > 0
+                InfoRow {}
+            }
 
-                    StyledText {
-                        text: modelData.label || ""
-                        color: Colours.palette.m3onSurfaceVariant
-                        font: Tokens.font.label.medium
-                    }
+            // Rich media metadata (EXIF / container tags)
+            Repeater {
+                model: meta.mediaDetails
 
-                    StyledText {
-                        Layout.fillWidth: true
-                        text: modelData.value ? String(modelData.value) : ""
-                        color: Colours.palette.m3onSurface
-                        font: Tokens.font.body.small
-                        wrapMode: Text.Wrap
-                    }
-                }
+                InfoRow {}
             }
         }
     }

--- a/src/core/exifreader.cpp
+++ b/src/core/exifreader.cpp
@@ -1,0 +1,193 @@
+#include "exifreader.hpp"
+#include "fileutils.hpp"
+
+#include <QDateTime>
+#include <QStringList>
+
+#ifdef PRISM_HAVE_EXIV2
+#include <exiv2/exiv2.hpp>
+#endif
+
+namespace atlas::core {
+namespace {
+
+void appendRow(QVariantList& rows, const QString& label, const QString& value) {
+    if (!value.simplified().isEmpty()) {
+        rows.append(QVariantMap{{"label", label}, {"value", value}});
+    }
+}
+
+#ifdef PRISM_HAVE_EXIV2
+
+// "48/1 8/1 4506/100" + "N" -> "48.1459° N"
+QString formatGpsCoordinate(const QString& rationals, const QString& ref) {
+    const QStringList parts = rationals.split(' ', Qt::SkipEmptyParts);
+    if (parts.size() != 3 || ref.isEmpty()) return QString();
+
+    double degrees[3] = {0.0, 0.0, 0.0};
+    for (int i = 0; i < 3; ++i) {
+        const QStringList frac = parts[i].split('/');
+        bool okNum = false, okDen = false;
+        const double numerator = frac.value(0).toDouble(&okNum);
+        const double denominator = frac.value(1).toDouble(&okDen);
+        if (!okNum || !okDen || denominator == 0.0) return QString();
+        degrees[i] = numerator / denominator;
+    }
+
+    const double decimal = degrees[0] + degrees[1] / 60.0 + degrees[2] / 3600.0;
+    return QStringLiteral("%1° %2").arg(decimal, 0, 'f', 4).arg(ref.at(0));
+}
+
+// "1/250" -> "1/250 s", "2" -> "2 s"
+QString formatExposure(const QString& rational) {
+    if (rational.isEmpty()) return QString();
+    const QStringList frac = rational.split('/');
+    if (frac.size() == 2 && frac[1].toDouble() > 0.0) {
+        const double seconds = frac[0].toDouble() / frac[1].toDouble();
+        if (seconds >= 10.0) return QStringLiteral("%1 s").arg(QString::number(seconds, 'f', 0));
+        return QStringLiteral("%1 s").arg(rational);
+    }
+    return QStringLiteral("%1 s").arg(rational);
+}
+
+QString stripCharsetPrefix(QString comment) {
+    qsizetype start = 0;
+    if (comment.startsWith(QLatin1String("charset=\""), Qt::CaseInsensitive)) {
+        start = sizeof("charset=\"") - 1;
+        const qsizetype end = comment.indexOf(u'"', start);
+        if (end >= 0) start = end + 1;
+    } else if (comment.startsWith(QLatin1String("charset="), Qt::CaseInsensitive)) {
+        const qsizetype space = comment.indexOf(u' ');
+        if (space >= 0) start = space + 1;
+    }
+    return comment.mid(start).trimmed();
+}
+
+#endif // PRISM_HAVE_EXIV2
+
+} // namespace
+
+QVariantList ExifReader::read(const QString& filePath) {
+    QVariantList rows;
+
+#ifdef PRISM_HAVE_EXIV2
+    if (filePath.isEmpty()) return rows;
+
+    try {
+        auto image = Exiv2::ImageFactory::open(filePath.toStdString());
+        image->readMetadata();
+        const Exiv2::ExifData& exif = image->exifData();
+        if (exif.empty()) return rows;
+
+        auto find = [&exif](const std::string& key) {
+            return exif.findKey(Exiv2::ExifKey(key));
+        };
+        auto str = [&find, &exif](const std::string& key) -> QString {
+            auto it = find(key);
+            return it != exif.end() ? QString::fromUtf8(it->toString().c_str()) : QString();
+        };
+        auto num = [&find, &exif](const std::string& key) -> double {
+            auto it = find(key);
+            return it != exif.end() ? it->toFloat() : 0.0;
+        };
+
+        // Date taken, formatted per the user's date preference
+        const QDateTime taken =
+            QDateTime::fromString(str("Exif.Photo.DateTimeOriginal"), QStringLiteral("yyyy:MM:dd HH:mm:ss"));
+        appendRow(rows, "Date Taken", taken.isValid() ? FileUtils::formatDateTime(taken) : QString());
+
+        // Camera and lens
+        QString make = str("Exif.Image.Make");
+        QString model = str("Exif.Image.Model");
+        if (!make.isEmpty() && !model.isEmpty() && model.startsWith(make, Qt::CaseInsensitive)) {
+            model = model.mid(make.length()).trimmed();
+        }
+        QString camera = QStringList{make, model}.join(QStringLiteral(" ")).simplified();
+        appendRow(rows, "Camera", camera);
+        appendRow(rows, "Lens", str("Exif.Photo.LensModel"));
+
+        // Capture settings
+        appendRow(rows, "Exposure", formatExposure(str("Exif.Photo.ExposureTime")));
+        if (const double fNumber = num("Exif.Photo.FNumber"); fNumber > 0.0)
+            appendRow(rows, "Aperture", QStringLiteral("f/%1").arg(QString::number(fNumber, 'f', 1)));
+
+        QString iso;
+        for (const auto* key : {"Exif.Photo.ISOSpeedRatings", "Exif.Image.ISOSpeedRatings", "Exif.Photo.ISOSpeed"}) {
+            if (auto it = find(key); it != exif.end()) {
+                iso = QString::number(it->toInt64());
+                break;
+            }
+        }
+        appendRow(rows, "ISO", iso);
+
+        if (const double focal = num("Exif.Photo.FocalLength"); focal > 0.0)
+            appendRow(rows, "Focal Length",
+                      QStringLiteral("%1 mm").arg(focal == static_cast<double>(static_cast<int>(focal))
+                                                      ? QString::number(static_cast<int>(focal))
+                                                      : QString::number(focal, 'f', 1)));
+
+        if (auto it = find("Exif.Photo.Flash"); it != exif.end())
+            appendRow(rows, "Flash", it->toInt64() & 0x01 ? "Fired" : "Did not fire");
+
+        if (auto it = find("Exif.Photo.WhiteBalance"); it != exif.end())
+            appendRow(rows, "White Balance", it->toInt64() == 1 ? "Manual" : "Auto");
+
+        // Location
+        const QString latitude = formatGpsCoordinate(str("Exif.GPSInfo.GPSLatitude"), str("Exif.GPSInfo.GPSLatitudeRef"));
+        const QString longitude =
+            formatGpsCoordinate(str("Exif.GPSInfo.GPSLongitude"), str("Exif.GPSInfo.GPSLongitudeRef"));
+        QString gps = latitude;
+        if (!longitude.isEmpty()) gps += gps.isEmpty() ? longitude : QStringLiteral(", ") + longitude;
+        appendRow(rows, "GPS Coordinates", gps);
+
+        // Descriptive tags
+        appendRow(rows, "Software", str("Exif.Image.Software"));
+        const QString commentStr = stripCharsetPrefix(str("Exif.Photo.UserComment"));
+        rows.append(QVariantMap{{"label", "Comment"}, {"value", commentStr}});
+        appendRow(rows, "Description", str("Exif.Image.ImageDescription"));
+        appendRow(rows, "Copyright", str("Exif.Image.Copyright"));
+    } catch (const std::exception&) {
+        return QVariantList();
+    }
+#endif
+
+    return rows;
+}
+
+bool ExifReader::available() {
+#if defined(ATLAS_HAVE_EXIV2) || defined(PRISM_HAVE_EXIV2)
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool ExifReader::writeComment(const QString& filePath, const QString& comment) {
+#if defined(ATLAS_HAVE_EXIV2) || defined(PRISM_HAVE_EXIV2)
+    if (filePath.isEmpty()) return false;
+
+    try {
+        auto image = Exiv2::ImageFactory::open(filePath.toStdString());
+        image->readMetadata();
+        Exiv2::ExifData& exif = image->exifData();
+
+        const std::string key = "Exif.Photo.UserComment";
+        if (comment.trimmed().isEmpty()) {
+            auto it = exif.findKey(Exiv2::ExifKey(key));
+            if (it != exif.end()) exif.erase(it);
+        } else {
+            exif[key] = "charset=\"Ascii\" " + comment.toStdString();
+        }
+        image->writeMetadata();
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+#else
+    Q_UNUSED(filePath)
+    Q_UNUSED(comment)
+    return false;
+#endif
+}
+
+} // namespace atlas::core

--- a/src/core/exifreader.hpp
+++ b/src/core/exifreader.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QString>
+#include <QVariantList>
+
+namespace atlas::core {
+
+class ExifReader {
+public:
+    ExifReader() = delete;
+
+    // Ordered {label, value} rows extracted from an image file.
+    // Empty when built without Exiv2, on parse failure, or when no metadata exists.
+    [[nodiscard]] static QVariantList read(const QString& filePath);
+
+    // True when compiled with Exiv2 support.
+    [[nodiscard]] static bool available();
+
+    // Writes an EXIF UserComment string to the image file.
+    [[nodiscard]] static bool writeComment(const QString& filePath, const QString& comment);
+};
+
+} // namespace atlas::core

--- a/src/core/filemetadata.cpp
+++ b/src/core/filemetadata.cpp
@@ -1,4 +1,5 @@
 #include "filemetadata.hpp"
+#include "exifreader.hpp"
 #include "fileutils.hpp"
 
 #include <QCryptographicHash>
@@ -6,11 +7,49 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QImageReader>
+#include <QMediaMetaData>
+#include <QMediaPlayer>
 #include <QMimeDatabase>
 #include <QStandardPaths>
 #include <QUrl>
 
 namespace atlas::core {
+namespace {
+
+void appendDetailRow(QVariantList& rows, const QString& label, const QString& value) {
+    if (!value.simplified().isEmpty()) {
+        rows.append(QVariantMap{{"label", label}, {"value", value}});
+    }
+}
+
+QString formatDuration(qint64 milliseconds) {
+    if (milliseconds <= 0) return QString();
+    const qint64 totalSeconds = milliseconds / 1000;
+    const qint64 hours = totalSeconds / 3600;
+    const qint64 minutes = (totalSeconds % 3600) / 60;
+    const qint64 seconds = totalSeconds % 60;
+    if (hours > 0)
+        return QStringLiteral("%1:%2:%3").arg(hours).arg(minutes, 2, 10, QLatin1Char('0')).arg(seconds, 2, 10, QLatin1Char('0'));
+    return QStringLiteral("%1:%2").arg(minutes).arg(seconds, 2, 10, QLatin1Char('0'));
+}
+
+QString formatBitRate(qint64 bitsPerSecond) {
+    if (bitsPerSecond <= 0) return QString();
+    if (bitsPerSecond >= 1000000)
+        return QStringLiteral("%1 Mbps").arg(QString::number(bitsPerSecond / 1000000.0, 'f', 1));
+    if (bitsPerSecond >= 1000)
+        return QStringLiteral("%1 kbps").arg(QString::number(bitsPerSecond / 1000.0, 'f', 0));
+    return QStringLiteral("%1 bps").arg(bitsPerSecond);
+}
+
+QString formatFrameRate(qreal framesPerSecond) {
+    if (framesPerSecond <= 0.0) return QString();
+    if (framesPerSecond == static_cast<double>(static_cast<int>(framesPerSecond)))
+        return QStringLiteral("%1 fps").arg(static_cast<int>(framesPerSecond));
+    return QStringLiteral("%1 fps").arg(QString::number(framesPerSecond, 'f', 2));
+}
+
+} // namespace
 
 FileMetadata::FileMetadata(QObject* parent)
     : QObject(parent) {}
@@ -70,7 +109,10 @@ void FileMetadata::reload() {
         m_imageWidth = 0;
         m_imageHeight = 0;
         m_imageDimensions.clear();
+        m_lastModified = QDateTime();
+        resetMediaDetails();
         emit metadataChanged();
+        emit mediaDetailsChanged();
         return;
     }
 
@@ -132,6 +174,10 @@ void FileMetadata::reload() {
     m_formattedCreated = FileUtils::formatDateTime(fi.birthTime());
     m_formattedModified = FileUtils::formatDateTime(fi.lastModified());
     m_formattedAccessed = FileUtils::formatDateTime(fi.lastRead());
+    m_lastModified = fi.lastModified();
+
+    // Drop details from the previously selected file before re-populating
+    resetMediaDetails();
 
     if (m_isImage) {
         QImageReader reader(m_path);
@@ -145,13 +191,117 @@ void FileMetadata::reload() {
             m_imageHeight = 0;
             m_imageDimensions.clear();
         }
+
+        const QVariantList exifRows = ExifReader::read(m_path);
+        if (!exifRows.isEmpty()) {
+            m_mediaDetails = exifRows;
+            m_hasMediaDetails = true;
+        }
     } else {
         m_imageWidth = 0;
         m_imageHeight = 0;
         m_imageDimensions.clear();
     }
 
+    probeMediaMetadata();
+
     emit metadataChanged();
+    emit mediaDetailsChanged();
+}
+
+void FileMetadata::resetMediaDetails() {
+    m_hasMediaDetails = false;
+    m_videoDimensions.clear();
+    m_videoCodecName.clear();
+    m_audioCodecName.clear();
+    m_frameRate.clear();
+    m_bitRate.clear();
+    m_copyright.clear();
+    m_durationFormatted.clear();
+    m_audioTitle.clear();
+    m_audioArtist.clear();
+    m_audioAlbum.clear();
+    m_mediaDetails.clear();
+
+    if (m_mediaProbe && m_mediaProbe->source().isValid())
+        m_mediaProbe->setSource(QUrl());
+}
+
+void FileMetadata::probeMediaMetadata() {
+    if (!m_isVideo && !m_isAudio) return;
+
+    if (!m_mediaProbe) {
+        m_mediaProbe = new QMediaPlayer(this);
+        connect(m_mediaProbe, &QMediaPlayer::metaDataChanged, this, &FileMetadata::applyMediaMetaData);
+        connect(m_mediaProbe, &QMediaPlayer::errorOccurred, this,
+                [this](QMediaPlayer::Error, const QString&) {
+                    // Demux failed; leave details empty rather than retrying
+                });
+    }
+    m_mediaProbe->setSource(QUrl::fromLocalFile(m_path));
+}
+
+void FileMetadata::applyMediaMetaData() {
+    if (!m_mediaProbe) return;
+
+    const QUrl source = m_mediaProbe->source();
+    if (source.isValid() && source.toLocalFile() != m_path) return; // stale signal
+
+    const QMediaMetaData md = m_mediaProbe->metaData();
+    if (md.isEmpty()) return;
+
+    const QSize resolution = md.value(QMediaMetaData::Resolution).toSize();
+    m_videoDimensions = resolution.isValid()
+                           ? QStringLiteral("%1 × %2").arg(resolution.width()).arg(resolution.height())
+                           : QString();
+
+    m_durationFormatted = formatDuration(md.value(QMediaMetaData::Duration).toLongLong());
+    m_videoCodecName = md.stringValue(QMediaMetaData::VideoCodec);
+    m_audioCodecName = md.stringValue(QMediaMetaData::AudioCodec);
+    m_frameRate = formatFrameRate(md.value(QMediaMetaData::VideoFrameRate).toReal());
+
+    const qint64 videoRate = md.value(QMediaMetaData::VideoBitRate).toLongLong();
+    const qint64 audioRate = md.value(QMediaMetaData::AudioBitRate).toLongLong();
+    m_bitRate = formatBitRate(videoRate > 0 ? videoRate : audioRate);
+
+    m_copyright = md.stringValue(QMediaMetaData::Copyright);
+    m_audioTitle = md.stringValue(QMediaMetaData::Title);
+    m_audioAlbum = md.stringValue(QMediaMetaData::AlbumTitle);
+    for (const auto key : {QMediaMetaData::AlbumArtist, QMediaMetaData::ContributingArtist, QMediaMetaData::LeadPerformer}) {
+        const QString artist = md.stringValue(key);
+        if (!artist.isEmpty()) {
+            m_audioArtist = artist;
+            break;
+        }
+    }
+
+    QVariantList rows;
+    appendDetailRow(rows, "Title", m_audioTitle);
+    appendDetailRow(rows, "Artist", m_audioArtist);
+    appendDetailRow(rows, "Album", m_audioAlbum);
+    appendDetailRow(rows, "Track", md.value(QMediaMetaData::TrackNumber).toString());
+    appendDetailRow(rows, "Genre", md.stringValue(QMediaMetaData::Genre));
+    appendDetailRow(rows, "Resolution", m_videoDimensions);
+    appendDetailRow(rows, "Duration", m_durationFormatted);
+    appendDetailRow(rows, "Container", md.stringValue(QMediaMetaData::FileFormat));
+    appendDetailRow(rows, "Video Codec", m_videoCodecName);
+    appendDetailRow(rows, "Frame Rate", m_frameRate);
+    if (videoRate > 0) appendDetailRow(rows, "Video Bit Rate", formatBitRate(videoRate));
+    appendDetailRow(rows, "Audio Codec", m_audioCodecName);
+    if (audioRate > 0) appendDetailRow(rows, "Audio Bit Rate", formatBitRate(audioRate));
+
+    const QDateTime recorded = md.value(QMediaMetaData::Date).toDateTime();
+    if (recorded.isValid()) appendDetailRow(rows, "Recorded", FileUtils::formatDateTime(recorded));
+
+    QString comment = md.stringValue(QMediaMetaData::Comment);
+    if (comment.isEmpty()) comment = md.stringValue(QMediaMetaData::Description);
+    appendDetailRow(rows, "Comment", comment);
+    appendDetailRow(rows, "Copyright", m_copyright);
+
+    m_hasMediaDetails = !rows.isEmpty();
+    m_mediaDetails = rows;
+    emit metadataChanged();
+    emit mediaDetailsChanged();
 }
 
 void FileMetadata::calculateChecksums() {
@@ -254,6 +404,15 @@ bool FileMetadata::applyPermissions(int userRead, int userWrite, int userExec,
     });
 
     return true;
+}
+
+bool FileMetadata::setComment(const QString& comment) {
+    if (m_path.isEmpty() || !m_isImage) return false;
+    const bool ok = ExifReader::writeComment(m_path, comment);
+    if (ok) {
+        reload();
+    }
+    return ok;
 }
 
 } // namespace atlas::core

--- a/src/core/filemetadata.hpp
+++ b/src/core/filemetadata.hpp
@@ -3,7 +3,10 @@
 #include <QObject>
 #include <QString>
 #include <QDateTime>
+#include <QVariantList>
 #include <qqmlintegration.h>
+
+class QMediaPlayer;
 
 namespace atlas::core {
 
@@ -43,6 +46,16 @@ class FileMetadata : public QObject {
     Q_PROPERTY(QString audioArtist READ audioArtist NOTIFY metadataChanged)
     Q_PROPERTY(QString audioAlbum READ audioAlbum NOTIFY metadataChanged)
     Q_PROPERTY(QString durationFormatted READ durationFormatted NOTIFY metadataChanged)
+    Q_PROPERTY(QDateTime lastModified READ lastModified NOTIFY metadataChanged)
+    Q_PROPERTY(qint64 lastModifiedMs READ lastModifiedMs NOTIFY metadataChanged)
+    Q_PROPERTY(bool hasMediaDetails READ hasMediaDetails NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString videoDimensions READ videoDimensions NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString videoCodecName READ videoCodecName NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString audioCodecName READ audioCodecName NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString frameRate READ frameRate NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString bitRate READ bitRate NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QString copyright READ copyright NOTIFY mediaDetailsChanged)
+    Q_PROPERTY(QVariantList mediaDetails READ mediaDetails NOTIFY mediaDetailsChanged)
 
 public:
     explicit FileMetadata(QObject* parent = nullptr);
@@ -83,20 +96,36 @@ public:
     QString audioAlbum() const { return m_audioAlbum; }
     QString durationFormatted() const { return m_durationFormatted; }
 
+    QDateTime lastModified() const { return m_lastModified; }
+    qint64 lastModifiedMs() const { return m_lastModified.isValid() ? m_lastModified.toMSecsSinceEpoch() : 0; }
+    bool hasMediaDetails() const { return m_hasMediaDetails; }
+    QString videoDimensions() const { return m_videoDimensions; }
+    QString videoCodecName() const { return m_videoCodecName; }
+    QString audioCodecName() const { return m_audioCodecName; }
+    QString frameRate() const { return m_frameRate; }
+    QString bitRate() const { return m_bitRate; }
+    QString copyright() const { return m_copyright; }
+    QVariantList mediaDetails() const { return m_mediaDetails; }
+
     Q_INVOKABLE void reload();
     Q_INVOKABLE void calculateChecksums();
     Q_INVOKABLE bool applyPermissions(int userRead, int userWrite, int userExec,
                                      int groupRead, int groupWrite, int groupExec,
                                      int otherRead, int otherWrite, int otherExec,
                                      bool recursive = false);
+    Q_INVOKABLE bool setComment(const QString& comment);
 
 signals:
     void pathChanged();
     void metadataChanged();
     void checksumsChanged();
+    void mediaDetailsChanged();
 
 private:
     QString findThumbnail(const QString& filePath);
+    void resetMediaDetails();
+    void probeMediaMetadata();
+    void applyMediaMetaData();
 
     QString m_path;
     QString m_name;
@@ -130,6 +159,16 @@ private:
     QString m_audioArtist;
     QString m_audioAlbum;
     QString m_durationFormatted;
+    QDateTime m_lastModified;
+    bool m_hasMediaDetails = false;
+    QString m_videoDimensions;
+    QString m_videoCodecName;
+    QString m_audioCodecName;
+    QString m_frameRate;
+    QString m_bitRate;
+    QString m_copyright;
+    QVariantList m_mediaDetails;
+    QMediaPlayer* m_mediaProbe = nullptr;
 };
 
 } // namespace atlas::core


### PR DESCRIPTION
### Summary

This PR adds metadata extraction and preview support for media files (videos, audio tracks, and photos) across both the F1 Preview Panel and the Properties modal, alongside several UI/rendering refinements.

---

### Key Changes

#### 1. Media & EXIF Metadata Extraction
- **Videos & Audio (`Qt6::Multimedia`)**: Extracts stream dimensions/resolution, exact duration, video/audio codecs, framerates (e.g. 144 fps), bitrates, recorded date, and ID3 audio tags (Title, Artist, Album) via an asynchronous `QMediaPlayer` probe.
- **Photos (`Exiv2`)**: Integrated `ExifReader` (`src/core/exifreader.cpp/.hpp`) to extract camera make/model, lens model, aperture, shutter speed, ISO, focal length, flash/white balance, software, capture date, and GPS coordinates.
- **Graceful Build Fallback**: Exiv2 is resolved optionally via `find_package(exiv2 QUIET)`. If Exiv2 is not installed, CMake builds cleanly without errors while video/audio metadata continues to function.

#### 2. UI & Preview Panel Improvements
- **Properties Modal (`PropertiesModal.qml`)**:
  - Added a dynamic **Details** tab rendered when media metadata is present (labelled dynamically as *Container Metadata*, *Audio Tags*, or *EXIF Metadata*).
- **Preview Panel (`PreviewPanel.qml`)**:
  - Enlarged media preview cards to 200px and unified video/image rendering into the main `Image` component with aspect-ratio preservation (`Image.PreserveAspectFit`), avoiding tiny 72px constrained thumbnails for videos.
  - Added `Resolution` and `Duration` rows to the sidebar metadata list.
  - Exposed `lastModifiedMs` (`qint64`) in `FileMetadata` to ensure reliable thumbnail cache busting in QML.
- **StateLayer & Tab Fixes**:
  - Adjusted button row item text bounds and alignment.
  
  
<img width="1563" height="961" alt="image" src="https://github.com/user-attachments/assets/2277f9df-7939-4319-9f1d-6a78aa699f8d" />

<img width="632" height="608" alt="image" src="https://github.com/user-attachments/assets/9a5b17e8-0f9a-4bdb-ac28-87509d5a33fd" />
