### PR TITLE
fix: scroll pixel precise devices one to one

### DIFF
--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -176,20 +176,19 @@ Item {
             target: gridView
             acceptedModifiers: Qt.NoModifier
             onWheel: event => {
-                let vx = 0;
-                let factor = AppController.scrollSpeed;
-                if (event.pixelDelta.x !== 0) {
-                    vx = event.pixelDelta.x * 25 * factor;
-                } else if (event.pixelDelta.y !== 0) {
-                    vx = event.pixelDelta.y * 25 * factor;
-                } else if (event.angleDelta.y !== 0) {
-                    vx = event.angleDelta.y * 14 * factor;
-                } else if (event.angleDelta.x !== 0) {
-                    vx = event.angleDelta.x * 14 * factor;
-                }
-                if (vx !== 0) {
-                    gridView.flick(vx, 0);
+                const factor = AppController.scrollSpeed;
+                const pixels = event.pixelDelta.x !== 0 ? event.pixelDelta.x : event.pixelDelta.y;
+                if (pixels !== 0) {
+                    const limit = Math.max(0, gridView.contentWidth - gridView.width);
+                    gridView.cancelFlick();
+                    gridView.contentX = Math.max(0, Math.min(limit, gridView.contentX - pixels * factor));
                     event.accepted = true;
+                } else {
+                    const angle = event.angleDelta.y !== 0 ? event.angleDelta.y : event.angleDelta.x;
+                    if (angle !== 0) {
+                        gridView.flick(angle * 14 * factor, 0);
+                        event.accepted = true;
+                    }
                 }
             }
         }
@@ -603,20 +602,19 @@ Item {
                 }
                 wheel.accepted = true;
             } else {
-                let vx = 0;
-                let factor = AppController.scrollSpeed;
-                if (wheel.pixelDelta.x !== 0) {
-                    vx = wheel.pixelDelta.x * 25 * factor;
-                } else if (wheel.pixelDelta.y !== 0) {
-                    vx = wheel.pixelDelta.y * 25 * factor;
-                } else if (wheel.angleDelta.y !== 0) {
-                    vx = wheel.angleDelta.y * 14 * factor;
-                } else if (wheel.angleDelta.x !== 0) {
-                    vx = wheel.angleDelta.x * 14 * factor;
-                }
-                if (vx !== 0) {
-                    gridView.flick(vx, 0);
+                const factor = AppController.scrollSpeed;
+                const pixels = wheel.pixelDelta.x !== 0 ? wheel.pixelDelta.x : wheel.pixelDelta.y;
+                if (pixels !== 0) {
+                    const limit = Math.max(0, gridView.contentWidth - gridView.width);
+                    gridView.cancelFlick();
+                    gridView.contentX = Math.max(0, Math.min(limit, gridView.contentX - pixels * factor));
                     wheel.accepted = true;
+                } else {
+                    const angle = wheel.angleDelta.y !== 0 ? wheel.angleDelta.y : wheel.angleDelta.x;
+                    if (angle !== 0) {
+                        gridView.flick(angle * 14 * factor, 0);
+                        wheel.accepted = true;
+                    }
                 }
             }
         }

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -489,15 +489,14 @@ Item {
                 target: listView
                 acceptedModifiers: Qt.NoModifier
                 onWheel: event => {
-                    let vy = 0;
-                    let factor = AppController.scrollSpeed;
+                    const factor = AppController.scrollSpeed;
                     if (event.pixelDelta.y !== 0) {
-                        vy = event.pixelDelta.y * 25 * factor;
+                        const limit = Math.max(0, listView.contentHeight - listView.height);
+                        listView.cancelFlick();
+                        listView.contentY = Math.max(0, Math.min(limit, listView.contentY - event.pixelDelta.y * factor));
+                        event.accepted = true;
                     } else if (event.angleDelta.y !== 0) {
-                        vy = event.angleDelta.y * 14 * factor;
-                    }
-                    if (vy !== 0) {
-                        listView.flick(0, vy);
+                        listView.flick(0, event.angleDelta.y * 14 * factor);
                         event.accepted = true;
                     }
                 }
@@ -923,15 +922,14 @@ Item {
                 }
                 wheel.accepted = true;
             } else {
-                let vy = 0;
-                let factor = AppController.scrollSpeed;
+                const factor = AppController.scrollSpeed;
                 if (wheel.pixelDelta.y !== 0) {
-                    vy = wheel.pixelDelta.y * 25 * factor;
+                    const limit = Math.max(0, listView.contentHeight - listView.height);
+                    listView.cancelFlick();
+                    listView.contentY = Math.max(0, Math.min(limit, listView.contentY - wheel.pixelDelta.y * factor));
+                    wheel.accepted = true;
                 } else if (wheel.angleDelta.y !== 0) {
-                    vy = wheel.angleDelta.y * 14 * factor;
-                }
-                if (vy !== 0) {
-                    listView.flick(0, vy);
+                    listView.flick(0, wheel.angleDelta.y * 14 * factor);
                     wheel.accepted = true;
                 }
             }

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -186,15 +186,14 @@ Item {
             target: view
             acceptedModifiers: Qt.NoModifier
             onWheel: event => {
-                let vy = 0;
-                let factor = AppController.scrollSpeed;
+                const factor = AppController.scrollSpeed;
                 if (event.pixelDelta.y !== 0) {
-                    vy = event.pixelDelta.y * 25 * factor;
+                    const limit = Math.max(0, view.contentHeight - view.height);
+                    view.cancelFlick();
+                    view.contentY = Math.max(0, Math.min(limit, view.contentY - event.pixelDelta.y * factor));
+                    event.accepted = true;
                 } else if (event.angleDelta.y !== 0) {
-                    vy = event.angleDelta.y * 14 * factor;
-                }
-                if (vy !== 0) {
-                    view.flick(0, vy);
+                    view.flick(0, event.angleDelta.y * 14 * factor);
                     event.accepted = true;
                 }
             }
@@ -653,15 +652,14 @@ Item {
                 }
                 wheel.accepted = true;
             } else {
-                let vy = 0;
-                let factor = AppController.scrollSpeed;
+                const factor = AppController.scrollSpeed;
                 if (wheel.pixelDelta.y !== 0) {
-                    vy = wheel.pixelDelta.y * 25 * factor;
+                    const limit = Math.max(0, view.contentHeight - view.height);
+                    view.cancelFlick();
+                    view.contentY = Math.max(0, Math.min(limit, view.contentY - wheel.pixelDelta.y * factor));
+                    wheel.accepted = true;
                 } else if (wheel.angleDelta.y !== 0) {
-                    vy = wheel.angleDelta.y * 14 * factor;
-                }
-                if (vy !== 0) {
-                    view.flick(0, vy);
+                    view.flick(0, wheel.angleDelta.y * 14 * factor);
                     wheel.accepted = true;
                 }
             }


### PR DESCRIPTION
## Problem

Reported by @iAmDeluded with a recording: scrolling by touchpad gesture crawls, while the same list scrolls normally with a wheel.

Both device kinds were funnelled into one call:

```qml
if (event.pixelDelta.y !== 0)
    vy = event.pixelDelta.y * 25 * factor;
else if (event.angleDelta.y !== 0)
    vy = event.angleDelta.y * 14 * factor;
view.flick(0, vy);
```

| device | one event reports | asks for a flick at |
|---|---|---|
| wheel | `angleDelta.y` = 120 | **1680** |
| touchpad | `pixelDelta.y` ≈ 5–15 | **≈ 250** |

And `flick()` *replaces* the flick in progress rather than adding to it. A touchpad sends a dense stream of those small events, so every one of them restarts a slow flick and no speed ever accumulates. That is the crawl in the recording.

## Change

A pixel delta is already the distance the content should travel, so it now moves the content directly by that amount, clamped to the extents, cancelling any flick in progress. That is how a pixel precise device is meant to be handled, and it also covers high resolution wheels that report pixel deltas.

An angle delta keeps exactly the flick it had before, same factor, so wheels behave as they did.

All three views carried the handler twice each — once plain, once in the else branch of the zoom shortcut — so six sites in total. `FileCompactView` scrolls horizontally and gets the same treatment on its own axis.

## Verified

Builds and runs clean. The wheel path is unchanged by construction: same expression, same factor, same call.

**The touchpad path needs someone with a touchpad to confirm**, which is what @iAmDeluded asked for in the first place — I cannot synthesise touchpad gesture events headlessly, so I can show the reasoning and the code but not the feel. @iAmDeluded, if you pull this one, the gesture should now track your fingers one to one rather than lagging behind them, and the scroll speed setting still scales it.
