### PR TITLE
fix: put the scrollbar against the window edge and make it easier to grab

### DIFF
--- a/qml/components/StyledScrollBar.qml
+++ b/qml/components/StyledScrollBar.qml
@@ -45,28 +45,13 @@ T.ScrollBar {
         }
     }
     
-    implicitWidth: isVertical ? Tokens.padding.extraSmall : 0
-    implicitHeight: isVertical ? 0 : Tokens.padding.extraSmall
+    readonly property int barThickness: Tokens.padding.extraSmall
+    readonly property int grabThickness: Tokens.padding.medium
 
-    contentItem: StyledRect {
-        anchors.left: isVertical ? parent.left : undefined
-        anchors.right: isVertical ? parent.right : undefined
-        anchors.top: isVertical ? undefined : parent.top
-        anchors.bottom: isVertical ? undefined : parent.bottom
-        
-        opacity: {
-            if (root.size === 1)
-                return 0;
-            if (fullMouse.pressed)
-                return 1;
-            if (mouse.containsMouse)
-                return 0.8;
-            if (root.policy === T.ScrollBar.AlwaysOn || root.shouldBeActive)
-                return 0.6;
-            return 0;
-        }
-        radius: Tokens.rounding.full
-        color: Colours.palette.m3secondary
+    implicitWidth: isVertical ? grabThickness : 0
+    implicitHeight: isVertical ? 0 : grabThickness
+
+    contentItem: Item {
 
         MouseArea {
             id: mouse
@@ -77,9 +62,34 @@ T.ScrollBar {
             acceptedButtons: Qt.NoButton
         }
 
-        Behavior on opacity {
-            Anim {
-                type: Anim.DefaultEffects
+        StyledRect {
+            id: bar
+
+            anchors.right: root.isVertical ? parent.right : undefined
+            anchors.left: root.isVertical ? undefined : parent.left
+            anchors.top: root.isVertical ? parent.top : undefined
+            anchors.bottom: parent.bottom
+            width: root.isVertical ? root.barThickness : parent.width
+            height: root.isVertical ? parent.height : root.barThickness
+            
+            opacity: {
+                if (root.size === 1)
+                    return 0;
+                if (fullMouse.pressed)
+                    return 1;
+                if (mouse.containsMouse)
+                    return 0.8;
+                if (root.policy === T.ScrollBar.AlwaysOn || root.shouldBeActive)
+                    return 0.6;
+                return 0;
+            }
+            radius: Tokens.rounding.full
+            color: Colours.palette.m3secondary
+
+            Behavior on opacity {
+                Anim {
+                    type: Anim.DefaultEffects
+                }
             }
         }
     }

--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -632,7 +632,16 @@ Item {
 
         readonly property real anchorViewX: anchorContentX + gridView.x - gridView.contentX
 
+        function insideContent(px, py) {
+            const p = mapToItem(gridView, px, py);
+            return p.x >= 0 && p.y >= 0 && p.x <= gridView.width && p.y <= gridView.height;
+        }
+
         onPressed: mouse => {
+            if (!insideContent(mouse.x, mouse.y)) {
+                mouse.accepted = false;
+                return;
+            }
             root.notifyFocus();
             startX = mouse.x;
             startY = mouse.y;

--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -161,6 +161,10 @@ Item {
 
         anchors.fill: parent
         anchors.margins: Tokens.padding.small
+        anchors.bottomMargin: 0
+
+        bottomMargin: Tokens.padding.small
+
         cellWidth: Math.max(220, 200 + root.iconSize)
         cellHeight: root.iconSize + 18
         flow: GridView.FlowTopToBottom

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -948,7 +948,16 @@ Item {
 
         readonly property real anchorViewY: anchorContentY + listView.y - listView.contentY
 
+        function insideContent(px, py) {
+            const p = mapToItem(listView, px, py);
+            return p.x >= 0 && p.y >= 0 && p.x <= listView.width && p.y <= listView.height;
+        }
+
         onPressed: mouse => {
+            if (!insideContent(mouse.x, mouse.y)) {
+                mouse.accepted = false;
+                return;
+            }
             root.notifyFocus();
             startX = mouse.x;
             startY = mouse.y;

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -680,7 +680,16 @@ Item {
         readonly property real anchorViewX: anchorContentX + view.x - view.contentX
         readonly property real anchorViewY: anchorContentY + view.y - view.contentY
 
+        function insideContent(px, py) {
+            const p = mapToItem(view, px, py);
+            return p.x >= 0 && p.y >= 0 && p.x <= view.width && p.y <= view.height;
+        }
+
         onPressed: mouse => {
+            if (!insideContent(mouse.x, mouse.y)) {
+                mouse.accepted = false;
+                return;
+            }
             root.notifyFocus();
             startX = mouse.x;
             startY = mouse.y;

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -169,6 +169,9 @@ Item {
 
         anchors.fill: parent
         anchors.margins: Tokens.padding.extraSmall + Tokens.padding.medium
+        anchors.rightMargin: 0
+
+        rightMargin: Tokens.padding.extraSmall + Tokens.padding.medium
 
         // Exact uniform cell dimensions
         cellWidth: Math.max(144, root.zoomSize + 48)


### PR DESCRIPTION
## Problem

Reported by @Chujjo, in two parts.

**The target was four pixels.** `implicitWidth: Tokens.padding.extraSmall`, with the drag `MouseArea` filling it exactly.

**Aiming past it started a selection.** The flickables sit inset from the edge of the view — sixteen pixels in the grid, eight in the compact view — and that margin belonged to the drag select area.

And on review, a third thing that was really the root of the first two: **the bar was not at the edge of the window at all.** It sat wherever its flickable's edge happened to be, sixteen pixels in, which is why it felt awkward to reach in the first place.

## Change

**The bar is now against the edge.** The flickables reach their own edge and the padding the content needs moved to the flickable's content margin, where it belongs. The grid keeps five columns at the same window width and its items keep their spacing; only the scrollbar moved.

**The target is twelve pixels while the visible bar stays four.** The content item became a transparent full width item with the bar anchored inside it against the edge, so the control looks the same and only its reach changed. Hover moved to the wider area too, so the bar lights up when the pointer is anywhere in the target.

**A press outside the flickable no longer starts a rubber band selection**, derived from the flickable's own geometry rather than repeating each view's margins — the three views differ, and the details view has bars on both axes.

## Verified

At 822 wide:

| | before | after |
|---|---|---|
| gap between bar and window | 16 px | **0 px** |
| grab target | 4 px | **12 px** |
| visible bar | 4 px | 4 px |
| columns in the grid | 5 | 5 |
| press just past the bar | starts a selection | no selection |

Before on the left, after on the right:

![Scrollbar](https://raw.githubusercontent.com/eximora-private/Atlas/assets/scrollbar-flush.png)

## What is not in here

The details view. Its horizontal bar was already flush, and its vertical one sits eight pixels in because the whole content column is inset inside a horizontally scrolling flickable. Moving that means restructuring the layout rather than changing a margin, so it does not belong in this change.
