### PR TITLE
fix: return to the places manager after editing a place

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -193,6 +193,7 @@ ApplicationWindow {
                                 editPlaceModal.placePath = path;
                                 editPlaceModal.selectedIcon = iconName;
                                 editPlaceModal.isCustom = isCustom;
+                                editPlaceModal.reopenManager = false;
                                 editPlaceModal.expanded = true;
                             }
 
@@ -495,6 +496,7 @@ ApplicationWindow {
                 editPlaceModal.placePath = path;
                 editPlaceModal.selectedIcon = iconName;
                 editPlaceModal.isCustom = custom;
+                editPlaceModal.reopenManager = true;
                 editPlaceModal.expanded = true;
             }
         }
@@ -502,6 +504,16 @@ ApplicationWindow {
         // Edit Place Modal
         EditPlaceModal {
             id: editPlaceModal
+
+            property bool reopenManager: false
+
+            onExpandedChanged: {
+                if (!expanded && reopenManager) {
+                    reopenManager = false;
+                    placesManageModal.expanded = true;
+                }
+            }
+
             onAccepted: (idx, name, iconName) => {
                 PlacesModel.updatePlace(idx, name, iconName);
             }


### PR DESCRIPTION
## Problem

Reported by @Chujjo: editing a place from the manage dialog — picking an icon in particular — replaces the dialog you came from, and saving or cancelling leaves you with nothing on screen.

`PlacesManageModal.qml` closes itself before asking for the editor:

```qml
root.expanded = false;
root.editPlaceRequested(...);
```

and `EditPlaceModal` only ever sets its own `expanded` to false. Nothing brings the manager back.

## Change

The editor remembers whether it was opened from the manager, and reopens it when it closes — whichever way it was closed: saved, cancelled, dismissed with escape, or by clicking outside. Hooking `onExpandedChanged` rather than the accept and cancel handlers covers all four without repeating the call.

Reached from the sidebar's context menu instead, it closes to the window as before. There was no dialog underneath to return to, so reopening the manager there would put up a dialog the user never asked for.

## Verified

| route | manager after closing the editor |
|---|---|
| opened from the manage dialog | reopened |
| opened from the sidebar context menu | stays closed |
