### PR TITLE
feat: let the places sidebar be dragged wider

### DIFF
--- a/qml/components/panels/PlacesSidebar.qml
+++ b/qml/components/panels/PlacesSidebar.qml
@@ -607,7 +607,7 @@ StyledRect {
     MouseArea {
         id: resizeHandle
 
-        anchors.right: parent.right
+        anchors.left: parent.right
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: Tokens.padding.small

--- a/qml/components/panels/PlacesSidebar.qml
+++ b/qml/components/panels/PlacesSidebar.qml
@@ -78,6 +78,8 @@ StyledRect {
             id: flickable
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.rightMargin: -Tokens.padding.medium
+            rightMargin: Tokens.padding.medium
             contentHeight: contentCol.implicitHeight
             clip: true
             fadeAmount: 0.08
@@ -105,7 +107,7 @@ StyledRect {
 
             ColumnLayout {
                 id: contentCol
-                width: flickable.width
+                width: flickable.width - Tokens.padding.medium
                 spacing: Tokens.spacing.small
 
                 // Section 1: Local Places & Bookmarks
@@ -628,22 +630,6 @@ StyledRect {
                 return;
             const moved = mapToItem(null, event.x, 0).x - pressSceneX;
             AppController.sidebarWidth = pressWidth + moved;
-        }
-
-        StyledRect {
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-            implicitWidth: 2
-
-            color: Colours.palette.m3primary
-            opacity: resizeHandle.pressed ? 1 : (resizeHandle.containsMouse ? 0.6 : 0)
-
-            Behavior on opacity {
-                Anim {
-                    type: Anim.DefaultEffects
-                }
-            }
         }
     }
 }

--- a/qml/components/panels/PlacesSidebar.qml
+++ b/qml/components/panels/PlacesSidebar.qml
@@ -9,7 +9,7 @@ StyledRect {
     id: root
 
     required property var activeTab
-    property int sidebarWidth: 230
+    readonly property int sidebarWidth: AppController.sidebarWidth
 
     signal editPlaceRequested(int index, string name, string path, string iconName, bool isCustom)
     signal placeContextMenuRequested(real globalX, real globalY, int index, string name, string path, string iconName, bool isCustom, bool isTrash)
@@ -597,6 +597,51 @@ StyledRect {
                         }
 
                     }
+                }
+            }
+        }
+    }
+
+    MouseArea {
+        id: resizeHandle
+
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: Tokens.padding.small
+        z: 100
+
+        property real pressSceneX: 0
+        property int pressWidth: 0
+
+        cursorShape: Qt.SizeHorCursor
+        hoverEnabled: true
+        preventStealing: true
+
+        onPressed: event => {
+            pressSceneX = mapToItem(null, event.x, 0).x;
+            pressWidth = AppController.sidebarWidth;
+        }
+
+        onPositionChanged: event => {
+            if (!pressed)
+                return;
+            const moved = mapToItem(null, event.x, 0).x - pressSceneX;
+            AppController.sidebarWidth = pressWidth + moved;
+        }
+
+        StyledRect {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            implicitWidth: 2
+
+            color: Colours.palette.m3primary
+            opacity: resizeHandle.pressed ? 1 : (resizeHandle.containsMouse ? 0.6 : 0)
+
+            Behavior on opacity {
+                Anim {
+                    type: Anim.DefaultEffects
                 }
             }
         }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -177,6 +177,7 @@ ApplicationWindow {
                         // Places Sidebar
                         PlacesSidebar {
                             Layout.fillHeight: true
+                            z: 1
                             activeTab: TabManager.currentTab
 
                             onPlaceContextMenuRequested: (gx, gy, idx, name, path, iconName, custom, trash) => {

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -55,6 +55,7 @@ AppController::AppController(QObject* parent)
     m_showFreeSpace = settings.value("preferences/showFreeSpace", true).toBool();
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_iconZoomLevel = qBound(48, settings.value("session/iconZoomLevel", 80).toInt(), 180);
+    m_sidebarWidth = qBound(160, settings.value("session/sidebarWidth", 230).toInt(), 480);
     m_folderItemCount = settings.value("preferences/folderItemCount", 0).toInt();
     FileUtils::setFolderCountMode(m_folderItemCount);
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
@@ -150,6 +151,18 @@ void AppController::setIconZoomLevel(int level) {
     QSettings settings("astra-atlas", "atlas");
     settings.setValue("session/iconZoomLevel", clamped);
     emit iconZoomLevelChanged();
+}
+
+void AppController::setSidebarWidth(int width) {
+    const int clamped = qBound(160, width, 480);
+    if (m_sidebarWidth == clamped)
+        return;
+
+    m_sidebarWidth = clamped;
+
+    QSettings settings("astra-atlas", "atlas");
+    settings.setValue("session/sidebarWidth", clamped);
+    emit sidebarWidthChanged();
 }
 
 void AppController::setCaseSensitiveSort(bool sensitive) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -49,6 +49,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool showFreeSpace READ showFreeSpace WRITE setShowFreeSpace NOTIFY showFreeSpaceChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(int iconZoomLevel READ iconZoomLevel WRITE setIconZoomLevel NOTIFY iconZoomLevelChanged)
+    Q_PROPERTY(int sidebarWidth READ sidebarWidth WRITE setSidebarWidth NOTIFY sidebarWidthChanged)
     Q_PROPERTY(int folderItemCount READ folderItemCount WRITE setFolderItemCount NOTIFY folderItemCountChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
@@ -160,7 +161,9 @@ public:
     void setPlacesIconSize(int size);
 
     [[nodiscard]] int iconZoomLevel() const { return m_iconZoomLevel; }
+    [[nodiscard]] int sidebarWidth() const { return m_sidebarWidth; }
     void setIconZoomLevel(int level);
+    void setSidebarWidth(int width);
     [[nodiscard]] int folderItemCount() const { return m_folderItemCount; }
     void setFolderItemCount(int mode);
 
@@ -231,6 +234,7 @@ signals:
     void showFreeSpaceChanged();
     void placesIconSizeChanged();
     void iconZoomLevelChanged();
+    void sidebarWidthChanged();
     void folderItemCountChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
@@ -275,6 +279,7 @@ private:
     bool m_showFreeSpace = true;
     int m_placesIconSize = 20;
     int m_iconZoomLevel = 80;
+    int m_sidebarWidth = 230;
     int m_folderItemCount = 0;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;


### PR DESCRIPTION
## Problem

Asked for by @Chujjo, who described what Thunar does: "u can like drag it to make it wider and that's all". @dim-ghub's answer was that the width comes from tokens — it was in fact a plain property with `230` written into it.

## Change

A handle runs along the right edge, eight pixels wide, with a resize cursor. **No line, no visible border** — the cursor is the affordance. An earlier revision drew a hairline under the pointer and it read as a border rather than a grip, so it is gone.

The drag tracks the pointer in **scene** coordinates rather than the handle's own, because the handle moves along with the edge it is dragging — reading `event.x` alone would fight itself.

The width lives in `AppController` under `session/sidebarWidth`, clamped to 160–480, so it survives a restart and cannot be dragged to something unusable. The default is the same 230 as before.

The file dialog keeps its own fixed width on purpose. It is a small transient window, and a sidebar dragged to 480 in the manager has no business being that wide there.

**The sidebar's own scrollbar also sat inset**, the same complaint as #67 but a different container: its content column is indented twelve pixels and the bar rode that edge rather than the sidebar's. The flickable now reaches the sidebar's edge and the twelve pixels moved to its content margin, so the rows keep their spacing and only the bar moved.

## Verified

| set to | result |
|---|---|
| 340 | applied, written to the config |
| 9999 | clamped to 480 |
| 10 | clamped to 160 |
| after restart | comes back |

Scrollbar at 253 wide: ends at 253 with a zero gap, rows stay 229 wide. Before on the left, after on the right:

![Sidebar scrollbar](https://raw.githubusercontent.com/eximora-private/Atlas/assets/sidebar-scrollbar-flush.png)

Widths of 200 and 380, with the file area giving way:

![Resizable sidebar](https://raw.githubusercontent.com/eximora-private/Atlas/assets/resizable-sidebar.png)

@Chujjo — you said you were going to look into this yourself; if you had already started, say so and I will close this in favour of yours.
