### PR TITLE
chore: add issue forms and a pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check you are on a current build first. More than one report has turned out to be
+        a fix that was already merged but not yet compiled locally.
+
+  - type: input
+    id: version
+    attributes:
+      label: Build
+      description: The package version, or the output of `git log -1 --format=%h` if you built it yourself.
+      placeholder: astra-atlas 1.0.0-1, or 8bb6db3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where
+      description: Which part of Atlas. Pick the closest one.
+      options:
+        - Grid view
+        - Details view
+        - Compact view
+        - Places sidebar
+        - Preferences
+        - Properties dialog
+        - File picker / portal
+        - Somewhere else
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: What you did
+      description: The steps, in order. Include the detail that seems irrelevant — it is often the one that finds it.
+      placeholder: |
+        1. Open a folder with a long file name
+        2. Select it
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: result
+    attributes:
+      label: What happened, and what you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshot or recording
+      description: |
+        Drag files straight into this box. A screenshot beats a description, and for anything
+        that moves — scrolling, animation, drag and drop — a recording beats a screenshot.
+
+  - type: input
+    id: setup
+    attributes:
+      label: Anything specific about your setup
+      description: Only if it might matter — a touchpad, two monitors, HiDPI, an unusual icon theme, a compositor other than Hyprland.
+      placeholder: Touchpad, 150% scaling

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest something Atlas should be able to do
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What should it do
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: What are you trying to get done
+      description: |
+        The problem behind the request. This matters more than the proposed solution — there is
+        often a simpler way to the same place, and knowing the goal is what finds it.
+    validations:
+      required: true
+
+  - type: input
+    id: prior_art
+    attributes:
+      label: Somewhere this already exists
+      description: If another file manager does this, naming it is the fastest way to show what you mean.
+      placeholder: Thunar, Dolphin, Nautilus

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## What this changes
+
+
+
+## Why
+
+
+
+## How it was verified
+
+<!--
+What you actually did, not "works for me". If you could not verify part of it, say which part
+and why — that is useful, not a weakness.
+-->
+
+
+
+<!--
+Before opening:
+
+- Rebased on current main and built it there.
+- Debugging removed: commented-out lines, properties flipped to test something, timers added
+  to reproduce a bug.
+- Before and after screenshots if anything visual changed. Reviewing a layout change from a
+  diff is guesswork.
+- Unrelated changes left out, or explained in one sentence if they had to come along.
+
+If your fix looks like it does nothing, it may still be right — a second cause can mask it.
+Say so rather than dropping it.
+-->


### PR DESCRIPTION
## What this adds

`.github/ISSUE_TEMPLATE/bug_report.yml`, `feature_request.yml`, and `.github/pull_request_template.md`.

## Why these fields

Both required fields on the bug form are there because their absence has actually cost time:

**Build** — more than one report turned out to be a fix that was already merged and not yet compiled locally.

**Where** — a report that "the name touches the border" led to a fix for the wrong border; it was the bottom of the card, not the sides. A dropdown removes that guess entirely.

Evidence gets its own box because a recording is what made the touchpad scrolling report actionable at all, and a screenshot is what settles any layout question in one look.

The setup field is optional and exists so reports needing particular hardware say so — nobody without a touchpad can confirm a touchpad bug, and naming it is how the report finds the person who can.

The feature form asks what you are trying to get done alongside what you want built. The goal frequently has a shorter route than the proposed solution.

The pull request template asks what was verified and how, rather than for a description of the change — the diff already describes the change. The checklist is inside an HTML comment so it does not end up in the posted body.

## Notes

Labels are limited to `bug` and `enhancement`, both of which the repository already has, so nothing needs creating.

No `config.yml`: that is where a Discord link would go, and I do not have the invite. Say the word and I will add it.

Both YAML files parse.
