### PR TITLE
fix: accept a virtual location as the path argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,8 @@
 #include <QSurfaceFormat>
 
 #include <QSettings>
+
+#include "core/recentfiles.hpp"
 #include <QMouseEvent>
 
 #include "config/colours.hpp"
@@ -118,9 +120,13 @@ int main(int argc, char* argv[]) {
         if (p.startsWith(QLatin1String("file://"))) {
             p = QUrl(p).toLocalFile();
         }
-        QFileInfo fi(p);
-        if (fi.exists()) {
-            initialDir = fi.isDir() ? fi.absoluteFilePath() : fi.absolutePath();
+        if (atlas::core::RecentFiles::isRecentPath(p)) {
+            initialDir = p;
+        } else {
+            QFileInfo fi(p);
+            if (fi.exists()) {
+                initialDir = fi.isDir() ? fi.absoluteFilePath() : fi.absolutePath();
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`atlas recent:///` opens the home directory instead of Recent.

The positional argument is validated with `QFileInfo::exists`, and a virtual location is not a file, so the check drops it and the startup preference takes over. `TabManager` already makes this allowance when restoring a session, which is why Recent survives a restart but cannot be reached from a command line.

## Change

The argument is offered to `RecentFiles::isRecentPath` before being treated as a filesystem path, rather than comparing a prefix here — a second virtual location then only has to be taught to `RecentFiles`.

`-d recent:///` already worked and is untouched: that branch only reduces a file to its containing directory, so a path it does not recognise passes through.

## Verified

| invocation | before | after |
|---|---|---|
| `atlas recent:///` | home directory | Recent, 48 entries |
| `atlas -d recent:///` | Recent | Recent |
| `atlas ~/Bilder` | that directory | that directory |
| `atlas /does/not/exist` | startup preference | startup preference |