### PR TITLE
chore: remove the unreachable git panel entry point

### DIFF
--- a/qml/components/navigation/NavigationBar.qml
+++ b/qml/components/navigation/NavigationBar.qml
@@ -98,7 +98,6 @@ StyledRect {
     signal reload()
     signal searchRequested(string query)
     signal filterRequested(string filter)
-    signal gitRequested()
     signal preferencesRequested()
     signal specialProtocolInvoked(int protocolId)
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -123,10 +123,6 @@ ApplicationWindow {
                             }
                         }
 
-                        onGitRequested: {
-                            gitModal.expanded = true;
-                        }
-
                         onTogglePreview: {
                             previewPanel.expanded = !previewPanel.expanded;
                         }


### PR DESCRIPTION
`NavigationBar` declared a `gitRequested` signal and emitted it zero times, and `main.qml` connected a handler to it that therefore could never run. The handler body was identical to the status bar's, which is the path that actually opens the panel.

This looks like a toolbar entry point that was planned and never finished.

Worth noting because I got it wrong at first: removing the signal alone would have broken `main.qml`, which does connect to it. It is dead in the sense that nothing emits it, not in the sense that nothing references it — both halves have to go together.

Verified that the live route still works: emitting the status bar's `gitRequested` opens the panel.