### PR TITLE
fix: keep the details view scrollbar on screen

### DIFF
--- a/qml/components/StyledScrollBar.qml
+++ b/qml/components/StyledScrollBar.qml
@@ -10,6 +10,7 @@ T.ScrollBar {
     property bool animating: false
     property bool _updatingFromFlickable: false
     property bool _updatingFromUser: false
+    property bool animatePosition: true
 
     readonly property bool isVertical: root.orientation === Qt.Vertical
 
@@ -178,7 +179,7 @@ T.ScrollBar {
     }
 
     Behavior on position {
-        enabled: !fullMouse.pressed
+        enabled: root.animatePosition && !fullMouse.pressed
 
         Anim {}
     }

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -635,10 +635,6 @@ Item {
 
             model: root.model
 
-            ScrollBar.vertical: StyledScrollBar {
-                flickable: listView
-            }
-
             delegate: StyledRect {
                 id: rowItem
 
@@ -905,6 +901,23 @@ Item {
         }
     }
     }
+
+    StyledScrollBar {
+        id: verticalBar
+
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        z: 2
+
+        orientation: Qt.Vertical
+        flickable: listView
+        size: listView.contentHeight > 0 ? Math.min(1, listView.height / listView.contentHeight) : 1
+        position: listView.contentHeight > listView.height
+            ? Math.max(0, Math.min(1 - size, listView.contentY / listView.contentHeight))
+            : 0
+    }
+
 
     // Background Mouse Area for Deselection, Context Menu on empty space, and Rubber Band Selection
     MouseArea {

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -912,6 +912,7 @@ Item {
 
         orientation: Qt.Vertical
         flickable: listView
+        animatePosition: false
         size: listView.contentHeight > 0 ? Math.min(1, listView.height / listView.contentHeight) : 1
         position: listView.contentHeight > listView.height
             ? Math.max(0, Math.min(1 - size, listView.contentY / listView.contentHeight))


### PR DESCRIPTION
## Correction to what I said earlier

I described this as the bar sitting eight pixels in. It is worse than that.

The vertical bar lives **inside the horizontally scrolling content**, so it is positioned in content space rather than viewport space. Measured in a 466 wide window with columns 732 wide, it sat at **x 712 — 258 pixels past the right edge of the window**, invisible unless you first scrolled all the way right. The eight pixels only showed when the columns happened to fit.

## Change

The vertical bar is now a sibling of the horizontal flickable, anchored to the view's own right edge, driving the list directly. Its `size` and `position` are bound to the list rather than supplied by the attached property glue — that glue is what tied it to the scrolling content.

## A second commit, after testing

Driving `position` from the outside turned out to make every update run through `Behavior on position`, which the attached scrollbars never trigger — a C++ write from the attached object does not go through it. The bar lagged and overshot.

Measured against the same jump of `contentY` to 1000, target position 0.3388:

| | 120 ms | 240 ms | 480 ms |
|---|---|---|---|
| grid, attached | **0.3388** | 0.3388 | 0.3388 |
| details, before the fix | 0.2710 | **0.3421** | 0.3388 |

0.3421 is past the target — that is the overshoot that was visible in use.

`StyledScrollBar` now takes an `animatePosition` property, on by default so every attached use is untouched, and the details view turns it off because it supplies `position` itself. Measured again, it reaches 0.3388 at 120 ms like the grid.

## Verified

| | before | after |
|---|---|---|
| position in a 466 wide window | x 712, off screen | x 454–466, flush |
| after scrolling horizontally to 200 | moves with the content | stays put |
| reaching a new position | lagged and overshot | instant, like the grid |

Tracking the list: `position` 0.000 at the top and 0.915 at the bottom against a `size` of 0.085. The horizontal bar is unaffected.