### PR TITLE
feat: extract the sliding selector and use it in three more modals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ qt_add_qml_module(atlas_app
         qml/components/controls/ButtonRow.qml
         qml/components/controls/ButtonRowItem.qml
         qml/components/controls/ButtonGroup.qml
+        qml/components/controls/SlidingSelector.qml
         qml/components/controls/ButtonGroupItem.qml
         qml/components/controls/StyledSwitch.qml
         qml/components/controls/RowButton.qml

--- a/qml/components/controls/SlidingSelector.qml
+++ b/qml/components/controls/SlidingSelector.qml
@@ -1,0 +1,136 @@
+import QtQuick
+import QtQuick.Layouts
+import atlas
+import "../"
+
+StyledRect {
+    id: root
+
+    property var model: []
+    property var currentValue: undefined
+    property string valueKey: "value"
+    property string labelKey: "label"
+    property string iconKey: "icon"
+    property int buttonHeight: 40
+
+    property color activeColor: Colours.palette.m3primaryContainer
+    property color inactiveColor: Colours.tPalette.m3surfaceContainerHigh
+    property color activeOnColor: Colours.palette.m3onPrimaryContainer
+    property color inactiveOnColor: Colours.palette.m3onSurface
+    property color inactiveIconColor: Colours.palette.m3onSurfaceVariant
+
+    signal selected(var value, int index)
+
+    readonly property int currentIndex: {
+        for (let i = 0; i < root.model.length; ++i) {
+            if (root.model[i][root.valueKey] === root.currentValue)
+                return i;
+        }
+        return 0;
+    }
+
+    implicitHeight: buttonHeight
+    radius: Tokens.rounding.full
+    color: root.inactiveColor
+    clip: true
+
+    StyledRect {
+        id: indicator
+
+        readonly property Item target: repeater.count > root.currentIndex ? repeater.itemAt(root.currentIndex) : null
+
+        x: target ? target.x + 2 : 2
+        y: 2
+        width: target ? Math.max(0, target.width - 4) : 0
+        height: Math.max(0, root.height - 4)
+
+        radius: Tokens.rounding.full
+        color: root.activeColor
+
+        Behavior on x {
+            Anim {
+                type: Anim.DefaultSpatial
+            }
+        }
+
+        Behavior on width {
+            Anim {
+                type: Anim.DefaultSpatial
+            }
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        Repeater {
+            id: repeater
+
+            model: root.model
+
+            delegate: Item {
+                id: entry
+
+                required property int index
+                required property var modelData
+
+                readonly property bool isCurrent: root.currentIndex === entry.index
+                readonly property color contentColour: entry.isCurrent
+                    ? root.activeOnColor
+                    : (layer.containsMouse ? root.inactiveOnColor : root.inactiveIconColor)
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                StateLayer {
+                    id: layer
+
+                    anchors.fill: parent
+                    radius: Tokens.rounding.full
+                    color: entry.isCurrent ? root.activeOnColor : root.inactiveOnColor
+                    onClicked: root.selected(entry.modelData[root.valueKey], entry.index)
+                }
+
+                RowLayout {
+                    anchors.centerIn: parent
+                    spacing: 4
+
+                    MaterialIcon {
+                        visible: text.length > 0
+                        text: entry.modelData[root.iconKey] ?? ""
+                        color: entry.contentColour
+                        fontStyle: Tokens.font.icon.small
+                        fill: entry.isCurrent ? 1 : 0
+
+                        Behavior on color {
+                            CAnim {
+                                duration: Tokens.anim.durations.expressiveFastEffects
+                            }
+                        }
+
+                        Behavior on fill {
+                            Anim {
+                                type: Anim.DefaultEffects
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        text: entry.modelData[root.labelKey] ?? ""
+                        color: entry.contentColour
+                        font: entry.isCurrent
+                            ? Tokens.font.body.builders.small.weight(Font.DemiBold).build()
+                            : Tokens.font.body.small
+
+                        Behavior on color {
+                            CAnim {
+                                duration: Tokens.anim.durations.expressiveFastEffects
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/components/dialogs/BulkRenameModal.qml
+++ b/qml/components/dialogs/BulkRenameModal.qml
@@ -453,15 +453,10 @@ MouseArea {
             }
 
             // Sliding Pill Mode Selector Track
-            StyledRect {
-                id: pillTrack
+            SlidingSelector {
                 Layout.fillWidth: true
-                implicitHeight: 40
-                radius: Tokens.rounding.full
-                color: Colours.palette.m3surfaceContainerHigh
-                clip: true
 
-                readonly property var modesList: [
+                model: [
                     { id: "replace", label: qsTr("Replace"), icon: "find_replace" },
                     { id: "number", label: qsTr("Number"), icon: "format_list_numbered" },
                     { id: "insert", label: qsTr("Insert"), icon: "edit" },
@@ -469,86 +464,9 @@ MouseArea {
                     { id: "case", label: qsTr("Case"), icon: "text_format" },
                     { id: "date", label: qsTr("Date/Time"), icon: "schedule" }
                 ]
-
-                // Sliding Pill Indicator
-                StyledRect {
-                    id: slidingPill
-                    readonly property var currentItem: modesRepeater.count > root.modeIndex ? modesRepeater.itemAt(root.modeIndex) : null
-
-                    x: currentItem ? currentItem.x + 2 : (root.modeIndex * (pillTrack.width / Math.max(1, pillTrack.modesList.length)) + 2)
-                    y: 2
-                    width: currentItem ? Math.max(0, currentItem.width - 4) : Math.max(0, (pillTrack.width / Math.max(1, pillTrack.modesList.length)) - 4)
-                    height: Math.max(0, pillTrack.height - 4)
-                    radius: Tokens.rounding.full
-                    color: Colours.palette.m3primaryContainer
-
-                    Behavior on x {
-                        Anim { type: Anim.DefaultSpatial }
-                    }
-                    Behavior on width {
-                        Anim { type: Anim.DefaultSpatial }
-                    }
-                }
-
-                RowLayout {
-                    id: modesRow
-                    anchors.fill: parent
-                    spacing: 0
-
-                    Repeater {
-                        id: modesRepeater
-                        model: pillTrack.modesList
-
-                        delegate: Item {
-                            id: modeBtn
-                            required property int index
-                            required property var modelData
-
-                            readonly property bool isCurrent: root.modeIndex === modeBtn.index
-
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-
-                            StateLayer {
-                                id: modeStateLayer
-                                anchors.fill: parent
-                                radius: Tokens.rounding.full
-                                color: modeBtn.isCurrent ? Colours.palette.m3onPrimaryContainer : Colours.palette.m3onSurface
-                                onClicked: root.mode = modeBtn.modelData.id
-                            }
-
-                            RowLayout {
-                                id: modeContentRow
-                                anchors.centerIn: parent
-                                spacing: 4
-
-                                MaterialIcon {
-                                    text: modeBtn.modelData.icon
-                                    color: modeBtn.isCurrent
-                                        ? Colours.palette.m3onPrimaryContainer
-                                        : (modeStateLayer.containsMouse ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant)
-                                    fontStyle: Tokens.font.icon.small
-                                    fill: modeBtn.isCurrent ? 1 : 0
-
-                                    Behavior on color { CAnim { duration: Tokens.anim.durations.expressiveFastEffects } }
-                                    Behavior on fill { Anim { type: Anim.DefaultEffects } }
-                                }
-
-                                StyledText {
-                                    text: modeBtn.modelData.label
-                                    color: modeBtn.isCurrent
-                                        ? Colours.palette.m3onPrimaryContainer
-                                        : (modeStateLayer.containsMouse ? Colours.palette.m3onSurface : Colours.palette.m3onSurfaceVariant)
-                                    font: modeBtn.isCurrent
-                                        ? Tokens.font.body.builders.small.weight(Font.DemiBold).build()
-                                        : Tokens.font.body.small
-
-                                    Behavior on color { CAnim { duration: Tokens.anim.durations.expressiveFastEffects } }
-                                }
-                            }
-                        }
-                    }
-                }
+                valueKey: "id"
+                currentValue: root.mode
+                onSelected: value => root.mode = value
             }
 
             // Target Scope ("Apply to")

--- a/qml/components/dialogs/CompressModal.qml
+++ b/qml/components/dialogs/CompressModal.qml
@@ -122,7 +122,7 @@ MouseArea {
                 font: Tokens.font.label.medium
             }
 
-            ButtonRow {
+            SlidingSelector {
                 Layout.fillWidth: true
                 model: [
                     { label: ".zip", format: "zip" },

--- a/qml/components/dialogs/GitModal.qml
+++ b/qml/components/dialogs/GitModal.qml
@@ -137,12 +137,11 @@ MouseArea {
             }
 
             // Segmented Switcher
-            ButtonGroup {
+            SlidingSelector {
                 Layout.fillWidth: true
                 activeColor: Colours.palette.m3tertiaryContainer
                 activeOnColor: Colours.palette.m3onTertiaryContainer
                 inactiveColor: Colours.tPalette.m3surfaceContainerHigh
-                hoverColor: Colours.tPalette.m3surfaceContainerHighest
                 model: [
                     { tab: 0, label: qsTr("Branches (%1)").arg(GitManager.branches.length), icon: "fork_right" },
                     { tab: 1, label: qsTr("Recent Commits (%1)").arg(GitManager.commits.length), icon: "history" }

--- a/qml/components/dialogs/PropertiesModal.qml
+++ b/qml/components/dialogs/PropertiesModal.qml
@@ -107,10 +107,9 @@ MouseArea {
             }
 
             // Tab Bar Switcher
-            ButtonRow {
+            SlidingSelector {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 38
-                implicitHeight: 38
+                buttonHeight: 38
                 model: {
                     let tabs = [
                         { tab: 0, label: qsTr("General"), icon: "info" },


### PR DESCRIPTION
## What this does

The sliding pill selector lived as **97 lines inside `BulkRenameModal`**, so nothing else could use it. It is now `SlidingSelector`, carrying the same data driven interface `ButtonGroup` already has — `model`, `valueKey`, `labelKey`, `iconKey`, `currentValue`, `selected` — which makes each adoption a change of type name rather than a rewrite.

## Where it is used

| modal | selects | was |
|---|---|---|
| `GitModal` | Branches / Recent Commits | `ButtonGroup` |
| `PropertiesModal` | the dialog's own tabs | `ButtonRow` |
| `CompressModal` | the archive format | `ButtonRow` |

All three are one of a few, mutually exclusive, with an icon and a label — the shape the control was built for.

![Selectors](https://raw.githubusercontent.com/eximora-private/Atlas/assets/sliding-selector.png)

## Where it is deliberately not used

**The top level tabs** in Preferences and Places Manage use `M3TopTabBar`. That is the right Material component for navigation at that level, and a pill track there would change the structure of those dialogs rather than their appearance.

**The five remaining `ButtonGroup`s inside `BulkRenameModal`** are sub options within a mode, often just two entries. A forty pixel track for a two way toggle would dominate the very dialog the control came from.

**`SplitButtonRow`** stays where a dropdown is the right shape — many entries, like the date format.

**`ConnectServerModal`** keeps the selector it was deliberately given in #78.

## Three details worth flagging

`GitModal` loses its `hoverColor` property; the component's `StateLayer` handles hover. Its tertiary colouring is preserved.

`PropertiesModal` was 38 pixels tall rather than 40, kept through `buttonHeight`.

`CompressModal` has no icons in its model, which the component handles by hiding the icon when there is no glyph.

## Verified

All four rendered. The pill sits behind the current entry in each, and in `BulkRenameModal` it visibly slides from Replace to Case when the mode changes, with the mode content following it.

Net effect on the tree: 93 lines removed from the modals, 136 added as a component that four places share.
