### PR TITLE
chore: build and start Atlas on every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: with Exiv2
+            exiv2: true
+          - name: without Exiv2
+            exiv2: false
+
+    name: Build ${{ matrix.name }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed \
+            base-devel \
+            git \
+            cmake \
+            ninja \
+            qt6-base \
+            qt6-declarative \
+            qt6-multimedia \
+            qt6-shadertools \
+            qt6-svg
+          if [ "${{ matrix.exiv2 }}" = "true" ]; then
+            pacman -S --noconfirm --needed exiv2
+          fi
+
+      - name: Mark git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Start without QML errors
+        run: |
+          set -o pipefail
+          QT_QPA_PLATFORM=offscreen QT_LOGGING_TO_CONSOLE=1 \
+            timeout 20 ./build/bin/atlas "$HOME" > run.log 2>&1 || true
+
+          if grep -aiE '\.qml:[0-9]+.*(error|is not a type|Cannot |Unable to assign|TypeError)|binding loop' run.log; then
+            echo "::error::QML errors on startup, see the matches above"
+            exit 1
+          fi
+          echo "Started clean."
+
+      - name: Open the file picker without QML errors
+        run: |
+          set -o pipefail
+          QT_QPA_PLATFORM=offscreen QT_LOGGING_TO_CONSOLE=1 \
+            timeout 20 ./build/bin/atlas -p -d "$HOME" > picker.log 2>&1 || true
+
+          if grep -aiE '\.qml:[0-9]+.*(error|is not a type|Cannot |Unable to assign|TypeError)|binding loop' picker.log; then
+            echo "::error::QML errors in picker mode, see the matches above"
+            exit 1
+          fi
+          echo "Picker started clean."


### PR DESCRIPTION
Atlas has no CI, so every merge here has been verified by hand. That mostly worked, and once it did not — `main` was briefly broken by a QML property assigned twice, which the build catches immediately because `qmlcachegen` refuses it.

## What it does

Builds on Arch, which is what the project targets, **twice**: with Exiv2 present and with it absent. The optional dependency is a claim the code makes, and until now nothing checked the second half of it.

Then it **starts the application, and the picker**, under the offscreen platform, and fails if the log contains a QML error or a binding loop.

That second part is the half worth having. A QML file that compiles can still fail at load, and a binding loop never fails a build at all — those are exactly the two things I have been catching by hand all week.

## The detection was checked in both directions

| | result |
|---|---|
| clean build | three log lines, no match |
| a property referencing an undefined id | `ReferenceError`, caught |

A step that never fires is worse than no step, so it seemed worth proving rather than assuming.

## Not included

No tests, because there are none to run yet — Foundry has `ctest`, Atlas has no test target. If one appears this is where it goes.