### PR TITLE
feat: unfold a folder in place in the details view

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -354,6 +354,14 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "account_tree"
+                                    text: qsTr("Expandable Folders")
+                                    subtext: qsTr("Unfold a folder in place in the details view instead of opening it")
+                                    checked: AppController.expandableFolders
+                                    onToggled: checked => AppController.expandableFolders = checked
+                                }
+
+                                ToggleRow {
                                     icon: "folder_managed"
                                     text: qsTr("Remember View per Folder")
                                     subtext: qsTr("Keep the view mode and sort order each folder was last left in")

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -825,8 +825,48 @@ Item {
                     // Name + Icon + Symlink / Lock
                     RowLayout {
                         Layout.fillWidth: true
-                        Layout.minimumWidth: 120
+                        Layout.minimumWidth: 120 + (AppController.expandableFolders ? 18 + Tokens.spacing.small : 0)
                         spacing: Tokens.spacing.small
+
+                        Item {
+                            visible: AppController.expandableFolders
+                            implicitWidth: visible ? (rowItem.modelData ? rowItem.modelData.depth : 0) * Tokens.padding.medium : 0
+                            implicitHeight: 1
+                        }
+
+                        Item {
+                            visible: AppController.expandableFolders
+                            implicitWidth: visible ? 18 : 0
+                            implicitHeight: 18
+
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                visible: rowItem.modelData ? rowItem.modelData.isDir : false
+                                text: "chevron_right"
+                                rotation: (rowItem.modelData && rowItem.modelData.expanded) ? 90 : 0
+                                fontStyle: Tokens.font.icon.small
+                                color: expandArea.containsMouse
+                                    ? Colours.palette.m3onSurface
+                                    : Colours.palette.m3onSurfaceVariant
+
+                                Behavior on rotation {
+                                    Anim {
+                                        type: Anim.DefaultSpatial
+                                    }
+                                }
+                            }
+
+                            MouseArea {
+                                id: expandArea
+
+                                anchors.fill: parent
+                                anchors.margins: -4
+                                enabled: rowItem.modelData ? rowItem.modelData.isDir : false
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.model.toggleExpanded(rowItem.modelData.path)
+                            }
+                        }
 
                         Item {
                             implicitWidth: root.iconSize

--- a/qml/components/views/SplitViewContainer.qml
+++ b/qml/components/views/SplitViewContainer.qml
@@ -68,7 +68,13 @@ StyledRect {
     Connections {
         target: root.activeTab
         function onCurrentPathChanged() { root.applyDirectoryView(); }
-        function onViewModeChanged() { root.rememberDirectoryView(); }
+        function onViewModeChanged() {
+            root.rememberDirectoryView();
+            if (root.activeTab && root.activeTab.viewMode !== 1) {
+                if (mainModel) mainModel.collapseAll();
+                if (splitModel) splitModel.collapseAll();
+            }
+        }
     }
 
     Connections {
@@ -79,6 +85,13 @@ StyledRect {
 
     Connections {
         target: AppController
+        function onExpandableFoldersChanged() {
+            if (AppController.expandableFolders)
+                return;
+            if (mainModel) mainModel.collapseAll();
+            if (splitModel) splitModel.collapseAll();
+        }
+
         function onFolderItemCountChanged() {
             if (mainModel) mainModel.refresh();
             if (splitModel) splitModel.refresh();

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -56,6 +56,7 @@ AppController::AppController(QObject* parent)
     m_placesIconSize = settings.value("preferences/placesIconSize", 20).toInt();
     m_iconZoomLevel = qBound(48, settings.value("session/iconZoomLevel", 80).toInt(), 180);
     m_sidebarWidth = qBound(160, settings.value("session/sidebarWidth", 230).toInt(), 480);
+    m_expandableFolders = settings.value("preferences/expandableFolders", false).toBool();
     m_folderItemCount = settings.value("preferences/folderItemCount", 0).toInt();
     FileUtils::setFolderCountMode(m_folderItemCount);
     m_dateFormat = settings.value("preferences/dateFormat", 1).toInt();
@@ -151,6 +152,17 @@ void AppController::setIconZoomLevel(int level) {
     QSettings settings("astra-atlas", "atlas");
     settings.setValue("session/iconZoomLevel", clamped);
     emit iconZoomLevelChanged();
+}
+
+void AppController::setExpandableFolders(bool enabled) {
+    if (m_expandableFolders == enabled)
+        return;
+
+    m_expandableFolders = enabled;
+
+    QSettings settings("astra-atlas", "atlas");
+    settings.setValue("preferences/expandableFolders", enabled);
+    emit expandableFoldersChanged();
 }
 
 void AppController::setSidebarWidth(int width) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -50,6 +50,7 @@ class AppController : public QObject {
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(int iconZoomLevel READ iconZoomLevel WRITE setIconZoomLevel NOTIFY iconZoomLevelChanged)
     Q_PROPERTY(int sidebarWidth READ sidebarWidth WRITE setSidebarWidth NOTIFY sidebarWidthChanged)
+    Q_PROPERTY(bool expandableFolders READ expandableFolders WRITE setExpandableFolders NOTIFY expandableFoldersChanged)
     Q_PROPERTY(int folderItemCount READ folderItemCount WRITE setFolderItemCount NOTIFY folderItemCountChanged)
     Q_PROPERTY(QString selectedPath READ selectedPath NOTIFY selectedPathChanged)
     Q_PROPERTY(int iconThemeVersion READ iconThemeVersion NOTIFY iconThemeVersionChanged)
@@ -162,8 +163,10 @@ public:
 
     [[nodiscard]] int iconZoomLevel() const { return m_iconZoomLevel; }
     [[nodiscard]] int sidebarWidth() const { return m_sidebarWidth; }
+    [[nodiscard]] bool expandableFolders() const { return m_expandableFolders; }
     void setIconZoomLevel(int level);
     void setSidebarWidth(int width);
+    void setExpandableFolders(bool enabled);
     [[nodiscard]] int folderItemCount() const { return m_folderItemCount; }
     void setFolderItemCount(int mode);
 
@@ -235,6 +238,7 @@ signals:
     void placesIconSizeChanged();
     void iconZoomLevelChanged();
     void sidebarWidthChanged();
+    void expandableFoldersChanged();
     void folderItemCountChanged();
     void selectedPathChanged();
     void iconThemeVersionChanged();
@@ -280,6 +284,7 @@ private:
     int m_placesIconSize = 20;
     int m_iconZoomLevel = 80;
     int m_sidebarWidth = 230;
+    bool m_expandableFolders = false;
     int m_folderItemCount = 0;
     QString m_selectedPath;
     int m_iconThemeVersion = 0;

--- a/src/models/filesystemmodel.cpp
+++ b/src/models/filesystemmodel.cpp
@@ -55,6 +55,8 @@ QVariant FileSystemModel::data(const QModelIndex& index, int role) const {
     case OwnerRole: return entry->owner();
     case IsImageRole: return entry->isImage();
     case IsHiddenRole: return entry->isHidden();
+    case DepthRole: return entry->depth();
+    case ExpandedRole: return entry->expanded();
     case Qt::DisplayRole: return entry->name();
     default:
         return {};
@@ -76,7 +78,9 @@ QHash<int, QByteArray> FileSystemModel::roleNames() const {
         { PermissionsRole, "permissions" },
         { OwnerRole, "owner" },
         { IsImageRole, "isImage" },
-        { IsHiddenRole, "isHidden" }
+        { IsHiddenRole, "isHidden" },
+        { DepthRole, "depth" },
+        { ExpandedRole, "expanded" }
     };
 }
 
@@ -433,6 +437,21 @@ void FileSystemModel::scanDirectory(bool isPathReset) {
 }
 
 void FileSystemModel::updateDirectoryGranular(const QList<RawEntryData>& rawData) {
+    if (!m_expandedPaths.isEmpty()) {
+        QList<FileSystemEntry*> incoming;
+        incoming.reserve(rawData.size());
+        for (const RawEntryData& d : rawData)
+            incoming.append(createEntryFromRawData(d, this));
+
+        beginResetModel();
+        qDeleteAll(m_rawEntries);
+        m_rawEntries = incoming;
+        m_filteredEntries = calculateFilteredAndSorted(m_rawEntries);
+        endResetModel();
+        emit countChanged();
+        return;
+    }
+
     QList<QString> modifiedPaths;
     QHash<QString, FileSystemEntry*> existingMap;
     for (auto* e : m_rawEntries) {
@@ -557,7 +576,7 @@ void FileSystemModel::performSearch(const QString& rootPath, const QString& quer
     });
 }
 
-QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<FileSystemEntry*>& source) {
+QList<FileSystemEntry*> FileSystemModel::filterAndSortOnly(const QList<FileSystemEntry*>& source) const {
     QList<FileSystemEntry*> result;
     QString lowerFilter = m_filterText.toLower();
 
@@ -633,6 +652,80 @@ QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<
 
     std::sort(result.begin(), result.end(), comparator);
     return result;
+}
+
+QList<FileSystemEntry*> FileSystemModel::calculateFilteredAndSorted(const QList<FileSystemEntry*>& source) {
+    qDeleteAll(m_childEntries);
+    m_childEntries.clear();
+
+    QList<FileSystemEntry*> result = filterAndSortOnly(source);
+    if (m_expandedPaths.isEmpty())
+        return result;
+
+    QList<FileSystemEntry*> expandedResult;
+    expandedResult.reserve(result.size());
+    for (auto* e : result)
+        appendWithChildren(e, 0, expandedResult);
+    return expandedResult;
+}
+
+QList<FileSystemEntry*> FileSystemModel::childrenOf(const QString& path) {
+    QList<FileSystemEntry*> children;
+
+    QDir dir(path);
+    if (!dir.exists())
+        return children;
+
+    QDir::Filters filters = QDir::AllEntries | QDir::NoDotAndDotDot;
+    if (m_showHidden)
+        filters |= QDir::Hidden;
+
+    QMimeDatabase mimeDb;
+    const QFileInfoList infos = dir.entryInfoList(filters);
+    children.reserve(infos.size());
+    for (const QFileInfo& fi : infos) {
+        auto* entry = createEntryFromRawData(createRawDataFromInfo(fi, mimeDb), this);
+        m_childEntries.append(entry);
+        children.append(entry);
+    }
+
+    return filterAndSortOnly(children);
+}
+
+void FileSystemModel::appendWithChildren(FileSystemEntry* entry, int depth, QList<FileSystemEntry*>& out) {
+    const bool open = entry->isDir() && m_expandedPaths.contains(entry->path());
+    entry->setTreeState(depth, open);
+    out.append(entry);
+
+    if (!open)
+        return;
+
+    for (auto* child : childrenOf(entry->path()))
+        appendWithChildren(child, depth + 1, out);
+}
+
+void FileSystemModel::toggleExpanded(const QString& path) {
+    if (path.isEmpty())
+        return;
+
+    if (m_expandedPaths.contains(path)) {
+        for (const QString& open : QList<QString>(m_expandedPaths.begin(), m_expandedPaths.end())) {
+            if (open == path || open.startsWith(path + QLatin1Char('/')))
+                m_expandedPaths.remove(open);
+        }
+    } else {
+        m_expandedPaths.insert(path);
+    }
+
+    applyFilterAndSort();
+}
+
+void FileSystemModel::collapseAll() {
+    if (m_expandedPaths.isEmpty())
+        return;
+
+    m_expandedPaths.clear();
+    applyFilterAndSort();
 }
 
 void FileSystemModel::applyFilterAndSort() {

--- a/src/models/filesystemmodel.hpp
+++ b/src/models/filesystemmodel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QSet>
 #include <QDateTime>
 #include <QFileSystemWatcher>
 #include <QList>
@@ -63,6 +64,8 @@ class FileSystemEntry : public QObject {
     Q_PROPERTY(QString group READ group CONSTANT)
     Q_PROPERTY(QString suffix READ suffix CONSTANT)
     Q_PROPERTY(bool isHidden READ isHidden CONSTANT)
+    Q_PROPERTY(int depth READ depth NOTIFY treeChanged)
+    Q_PROPERTY(bool expanded READ expanded NOTIFY treeChanged)
     Q_PROPERTY(bool isReadOnly READ isReadOnly CONSTANT)
     Q_PROPERTY(bool isWritable READ isWritable CONSTANT)
     Q_PROPERTY(bool isImage READ isImage CONSTANT)
@@ -93,6 +96,16 @@ public:
     QString group() const { return m_group; }
     QString suffix() const { return m_suffix; }
     bool isHidden() const { return m_isHidden; }
+    int depth() const { return m_depth; }
+    bool expanded() const { return m_expanded; }
+    void setTreeState(int newDepth, bool isExpanded) {
+        if (m_depth == newDepth && m_expanded == isExpanded)
+            return;
+        m_depth = newDepth;
+        m_expanded = isExpanded;
+        emit treeChanged();
+    }
+
     bool isReadOnly() const { return m_isReadOnly; }
     bool isWritable() const { return m_isWritable; }
     bool isImage() const { return m_isImage; }
@@ -134,6 +147,11 @@ public:
     bool m_isVideo = false;
     bool m_hasThumbnail = false;
     bool m_isText = false;
+    int m_depth = 0;
+    bool m_expanded = false;
+
+signals:
+    void treeChanged();
 };
 
 class FileSystemModel : public QAbstractListModel {
@@ -177,7 +195,9 @@ public:
         PermissionsRole,
         OwnerRole,
         IsImageRole,
-        IsHiddenRole
+        IsHiddenRole,
+        DepthRole,
+        ExpandedRole
     };
     Q_ENUM(Roles)
 
@@ -223,6 +243,10 @@ public:
     Q_INVOKABLE int indexOfPath(const QString& path) const;
     Q_INVOKABLE int findFirstIndexByPrefix(const QString& prefix, int startIndex = 0) const;
     Q_INVOKABLE void refresh();
+    Q_INVOKABLE void toggleExpanded(const QString& path);
+    Q_INVOKABLE void collapseAll();
+    Q_INVOKABLE bool isExpanded(const QString& path) const { return m_expandedPaths.contains(path); }
+    [[nodiscard]] bool hasExpandedFolders() const { return !m_expandedPaths.isEmpty(); }
 
 signals:
     void pathChanged();
@@ -245,6 +269,9 @@ private:
     void applyFilterAndSort();
     void performSearch(const QString& rootPath, const QString& query);
     QList<FileSystemEntry*> calculateFilteredAndSorted(const QList<FileSystemEntry*>& source);
+    QList<FileSystemEntry*> filterAndSortOnly(const QList<FileSystemEntry*>& source) const;
+    void appendWithChildren(FileSystemEntry* entry, int depth, QList<FileSystemEntry*>& out);
+    QList<FileSystemEntry*> childrenOf(const QString& path);
 
     QString m_path;
     QString m_filterText;
@@ -262,6 +289,8 @@ private:
 
     QList<FileSystemEntry*> m_rawEntries;
     QList<FileSystemEntry*> m_filteredEntries;
+    QList<FileSystemEntry*> m_childEntries;
+    QSet<QString> m_expandedPaths;
     QFileSystemWatcher m_watcher;
 };
 


### PR DESCRIPTION
## What this adds

The last item of the Thunar parity list — `misc-expandable-folders`. I left it until now because it looked like a rewrite of the model. It is not, provided the tree stays a flat list.

`FileSystemModel` keeps the set of expanded paths and splices each open folder's children into the sorted result at `depth + 1`, recursively. Sorting stays per level. Because the splice happens at the end of the one function every rebuild goes through, an expansion survives a refresh, a sort change and a filter change with no extra bookkeeping.

![Expandable folders](https://raw.githubusercontent.com/eximora-private/Atlas/assets/expandable-folders.png)

## Two consequences worth naming

**The granular directory update falls back to a full rebuild while anything is expanded.** That path compares pointers of the top level, and children are rebuilt on every pass, so a diff would report every child as new. A watched directory that is also expanded therefore costs a reset rather than an insert. That seemed the better trade than teaching the diff about a hierarchy.

**Collapsing a folder also drops the expansions inside it**, so reopening it does not restore a tree the user cannot see.

## Scope

The chevron and the indent are details view only and appear only when the preference is on, which is **off by default**, as in Thunar. Switching to another view collapses everything — the model is shared between the three views and a grid full of spliced children would be wrong.

The name column reserves the chevron's width when the feature is on, so turning it on does not silently shorten every name. The per level indent still takes from the name, which is inherent to a tree in a fixed column.

## Verified

On a three level tree:

| step | rows |
|---|---|
| collapsed | `Ordner1@0  Ordner2@0  datei.txt@0` |
| expand Ordner1 | `Ordner1@0*  Unterordner@1  kind-a@1  kind-b@1  Ordner2@0  datei@0` |
| expand Unterordner | `… Unterordner@1*  enkel.txt@2  kind-a@1 …` |
| collapse Ordner1 | back to the original three |

Children land between the folder and the next top level entry, folders still sort before files at each level, and the nested expansion is cleared with its parent.
