### PR TITLE
fix: revive H in the details view, make the motions optional

### DIFF
--- a/qml/components/dialogs/PreferencesModal.qml
+++ b/qml/components/dialogs/PreferencesModal.qml
@@ -363,6 +363,14 @@ MouseArea {
                                 }
 
                                 ToggleRow {
+                                    icon: "keyboard"
+                                    text: qsTr("Vim Motions")
+                                    subtext: qsTr("Move with H, J, K and L instead of jumping to those letters")
+                                    checked: AppController.vimMotions
+                                    onToggled: checked => AppController.vimMotions = checked
+                                }
+
+                                ToggleRow {
                                     icon: "folder_managed"
                                     text: qsTr("Remember View per Folder")
                                     subtext: qsTr("Keep the view mode and sort order each folder was last left in")

--- a/qml/components/views/FileCompactView.qml
+++ b/qml/components/views/FileCompactView.qml
@@ -287,7 +287,7 @@ Item {
                         event.accepted = true;
                         return;
                     }
-                } else if (event.key === Qt.Key_H || event.key === Qt.Key_Left) {
+                } else if (event.key === Qt.Key_Left || (AppController.vimMotions && event.key === Qt.Key_H)) {
                     if (gridView.currentIndex === -1 && root.model && root.model.count > 0) {
                         gridView.currentIndex = 0;
                     } else {
@@ -295,7 +295,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+                } else if (event.key === Qt.Key_Down || (AppController.vimMotions && event.key === Qt.Key_J)) {
                     if (gridView.currentIndex === -1 && root.model && root.model.count > 0) {
                         gridView.currentIndex = 0;
                     } else {
@@ -303,7 +303,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+                } else if (event.key === Qt.Key_Up || (AppController.vimMotions && event.key === Qt.Key_K)) {
                     if (gridView.currentIndex === -1 && root.model && root.model.count > 0) {
                         gridView.currentIndex = 0;
                     } else {
@@ -311,7 +311,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_L || event.key === Qt.Key_Right) {
+                } else if (event.key === Qt.Key_Right || (AppController.vimMotions && event.key === Qt.Key_L)) {
                     if (gridView.currentIndex === -1 && root.model && root.model.count > 0) {
                         gridView.currentIndex = 0;
                     } else {

--- a/qml/components/views/FileDetailsView.qml
+++ b/qml/components/views/FileDetailsView.qml
@@ -592,7 +592,7 @@ Item {
                             event.accepted = true;
                             return;
                         }
-                    } else if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+                    } else if (event.key === Qt.Key_Down || (AppController.vimMotions && event.key === Qt.Key_J)) {
                         if (listView.currentIndex === -1 && root.model && root.model.count > 0) {
                             listView.currentIndex = 0;
                         } else if (listView.currentIndex < (root.model ? root.model.count - 1 : 0)) {
@@ -600,7 +600,7 @@ Item {
                         }
                         event.accepted = true;
                         return;
-                    } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+                    } else if (event.key === Qt.Key_Up || (AppController.vimMotions && event.key === Qt.Key_K)) {
                         if (listView.currentIndex > 0) {
                             listView.currentIndex--;
                         } else if (listView.currentIndex === -1 && root.model && root.model.count > 0) {
@@ -608,13 +608,13 @@ Item {
                         }
                         event.accepted = true;
                         return;
-                    } else if (event.key === Qt.Key_H || event.key === Qt.Key_Left) {
-                        if (root.activeTab && root.activeTab.canGoUp) {
+                    } else if (event.key === Qt.Key_Left || (AppController.vimMotions && event.key === Qt.Key_H)) {
+                        if (root.activeTab) {
                             root.activeTab.goUp();
                         }
                         event.accepted = true;
                         return;
-                    } else if (event.key === Qt.Key_L || event.key === Qt.Key_Right) {
+                    } else if (event.key === Qt.Key_Right || (AppController.vimMotions && event.key === Qt.Key_L)) {
                         if (root.currentItem) {
                             root.openItem(root.currentItem);
                         }

--- a/qml/components/views/FileGridView.qml
+++ b/qml/components/views/FileGridView.qml
@@ -292,7 +292,7 @@ Item {
                         event.accepted = true;
                         return;
                     }
-                } else if (event.key === Qt.Key_H || event.key === Qt.Key_Left) {
+                } else if (event.key === Qt.Key_Left || (AppController.vimMotions && event.key === Qt.Key_H)) {
                     if (view.currentIndex === -1 && root.model && root.model.count > 0) {
                         view.currentIndex = 0;
                     } else {
@@ -300,7 +300,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_J || event.key === Qt.Key_Down) {
+                } else if (event.key === Qt.Key_Down || (AppController.vimMotions && event.key === Qt.Key_J)) {
                     if (view.currentIndex === -1 && root.model && root.model.count > 0) {
                         view.currentIndex = 0;
                     } else {
@@ -308,7 +308,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_K || event.key === Qt.Key_Up) {
+                } else if (event.key === Qt.Key_Up || (AppController.vimMotions && event.key === Qt.Key_K)) {
                     if (view.currentIndex === -1 && root.model && root.model.count > 0) {
                         view.currentIndex = 0;
                     } else {
@@ -316,7 +316,7 @@ Item {
                     }
                     event.accepted = true;
                     return;
-                } else if (event.key === Qt.Key_L || event.key === Qt.Key_Right) {
+                } else if (event.key === Qt.Key_Right || (AppController.vimMotions && event.key === Qt.Key_L)) {
                     if (view.currentIndex === -1 && root.model && root.model.count > 0) {
                         view.currentIndex = 0;
                     } else {

--- a/src/core/appcontroller.cpp
+++ b/src/core/appcontroller.cpp
@@ -48,6 +48,7 @@ AppController::AppController(QObject* parent)
     m_showDirsFirst = settings.value("preferences/showDirsFirst", true).toBool();
     m_caseSensitiveSort = settings.value("preferences/caseSensitiveSort", false).toBool();
     m_directorySpecificViews = settings.value("preferences/directorySpecificViews", false).toBool();
+    m_vimMotions = settings.value("preferences/vimMotions", true).toBool();
 
     const QByteArray viewsJson = settings.value("preferences/directoryViews").toString().toUtf8();
     if (!viewsJson.isEmpty())
@@ -191,6 +192,17 @@ void AppController::setCaseSensitiveSort(bool sensitive) {
         settings.setValue("preferences/caseSensitiveSort", sensitive);
         emit caseSensitiveSortChanged();
     }
+}
+
+void AppController::setVimMotions(bool enabled) {
+    if (m_vimMotions == enabled)
+        return;
+
+    m_vimMotions = enabled;
+
+    QSettings settings("astra-atlas", "atlas");
+    settings.setValue("preferences/vimMotions", enabled);
+    emit vimMotionsChanged();
 }
 
 void AppController::setDirectorySpecificViews(bool enabled) {

--- a/src/core/appcontroller.hpp
+++ b/src/core/appcontroller.hpp
@@ -47,6 +47,7 @@ class AppController : public QObject {
     Q_PROPERTY(bool showDirsFirst READ showDirsFirst WRITE setShowDirsFirst NOTIFY showDirsFirstChanged)
     Q_PROPERTY(bool caseSensitiveSort READ caseSensitiveSort WRITE setCaseSensitiveSort NOTIFY caseSensitiveSortChanged)
     Q_PROPERTY(bool directorySpecificViews READ directorySpecificViews WRITE setDirectorySpecificViews NOTIFY directorySpecificViewsChanged)
+    Q_PROPERTY(bool vimMotions READ vimMotions WRITE setVimMotions NOTIFY vimMotionsChanged)
     Q_PROPERTY(bool showFreeSpace READ showFreeSpace WRITE setShowFreeSpace NOTIFY showFreeSpaceChanged)
     Q_PROPERTY(int placesIconSize READ placesIconSize WRITE setPlacesIconSize NOTIFY placesIconSizeChanged)
     Q_PROPERTY(int iconZoomLevel READ iconZoomLevel WRITE setIconZoomLevel NOTIFY iconZoomLevelChanged)
@@ -154,7 +155,9 @@ public:
     [[nodiscard]] bool caseSensitiveSort() const { return m_caseSensitiveSort; }
     void setCaseSensitiveSort(bool sensitive);
     [[nodiscard]] bool directorySpecificViews() const { return m_directorySpecificViews; }
+    [[nodiscard]] bool vimMotions() const { return m_vimMotions; }
     void setDirectorySpecificViews(bool enabled);
+    void setVimMotions(bool enabled);
     Q_INVOKABLE QVariantMap directoryView(const QString& path) const;
     Q_INVOKABLE void rememberDirectoryView(const QString& path, int viewMode, int sortField, int sortOrder);
     Q_INVOKABLE void forgetDirectoryViews();
@@ -239,6 +242,7 @@ signals:
     void showDirsFirstChanged();
     void caseSensitiveSortChanged();
     void directorySpecificViewsChanged();
+    void vimMotionsChanged();
     void showFreeSpaceChanged();
     void placesIconSizeChanged();
     void iconZoomLevelChanged();
@@ -285,6 +289,7 @@ private:
     bool m_showDirsFirst = true;
     bool m_caseSensitiveSort = false;
     bool m_directorySpecificViews = false;
+    bool m_vimMotions = true;
     QVariantMap m_directoryViews;
     bool m_showFreeSpace = true;
     int m_placesIconSize = 20;


### PR DESCRIPTION
Fixes #78.

## The bug under the complaint

> the details view has L to access folders and open files but H does not go back to the parent folder

It doesn't, and neither does Left. Both are guarded by a property that does not exist:

```qml
} else if (event.key === Qt.Key_H || event.key === Qt.Key_Left) {
    if (root.activeTab && root.activeTab.canGoUp) {
```

`TabItem` exposes `canGoBack` and `canGoForward`, never `canGoUp` — the string appears exactly once in the repository, in that read. It evaluates to `undefined`, the guard never passes, and the branch still sets `event.accepted = true`, so the key does not fall through to type-ahead either. H is simply inert.

`goUp()` already refuses to leave the root on its own, so the guard bought nothing.

| build | key | before | after |
|---|---|---|---|
| details view, motions on | `H` | stays in `atlas-keytest` | goes to parent |
| details view, motions on | `Left` | stays | goes to parent |

Measured by sending real key events to the window and reading `currentPath` either side.

## The design half

> it should either give the whole alphabet for search or give the whole keyboard just for vim motions

Right now every view takes H, J, K and L for motions, so type-ahead loses four letters mid-word — typing `haus` moves the selection instead of jumping to the file. Which trade is better genuinely depends on the person, so it is a preference rather than a decision made for everyone.

**On by default**, so nothing changes for anyone who has not asked. Turned off, all four letters go back to type-ahead and the arrow keys keep navigating either way. `/` still opens search in all three views.

![Vim Motions preference](https://raw.githubusercontent.com/eximora-private/Atlas/assets/vim-motions.png)

| motions | key | result |
|---|---|---|
| on | `H` | navigates up |
| on | `Left` | navigates up |
| off | `H` | no navigation, goes to type-ahead |
| off | `Left` | navigates up |

## Left alone

The reporter also asks for modal editing — counts, visual select, yank and put. That is a much larger feature than a preference and worth its own issue; this change only stops the current keys from fighting each other.
