### PR TITLE
fix: give the picker keyboard focus so Enter selects and closes

### DIFF
--- a/qml/components/filedialog/DialogButtons.qml
+++ b/qml/components/filedialog/DialogButtons.qml
@@ -10,6 +10,13 @@ StyledRect {
     required property var dialog
     required property var folder
 
+    function focusSaveName(): void {
+        saveNameInput.forceActiveFocus();
+        const name = root.dialog.saveName;
+        const dot = name.lastIndexOf(".");
+        saveNameInput.select(0, dot > 0 ? dot : name.length);
+    }
+
     function commitSave() {
         if (!root.dialog.saveMode)
             return;

--- a/qml/components/filedialog/FileDialog.qml
+++ b/qml/components/filedialog/FileDialog.qml
@@ -25,6 +25,15 @@ StyledRect {
     signal acceptedMultiple(var paths)
     signal rejected()
 
+    function claimFocus(): void {
+        if (saveMode)
+            dialogButtons.focusSaveName();
+        else
+            folderContents.focusView();
+    }
+
+    onVisibleChanged: if (visible) Qt.callLater(claimFocus)
+
     function pathToCwd(fullPath) {
         if (!fullPath || fullPath === "") return ["Home"];
         let home = FileUtils.home;
@@ -67,6 +76,8 @@ StyledRect {
         if (AppController.initialDirectory && AppController.initialDirectory.length > 0) {
             cwd = pathToCwd(AppController.initialDirectory);
         }
+        if (visible)
+            Qt.callLater(claimFocus);
     }
 
     Connections {
@@ -179,6 +190,8 @@ StyledRect {
             }
 
             DialogButtons {
+                id: dialogButtons
+
                 Layout.fillWidth: true
                 dialog: root
                 folder: folderContents

--- a/qml/components/filedialog/FolderContents.qml
+++ b/qml/components/filedialog/FolderContents.qml
@@ -371,6 +371,12 @@ Item {
         }
     }
 
+    function focusView() {
+        view.forceActiveFocus();
+        if (view.currentIndex === -1 && fsModel.count > 0)
+            view.currentIndex = 0;
+    }
+
     function handleItemClick(file) {
         if (!file) return;
         if (file.isDir) {


### PR DESCRIPTION
Fixes #80.

## Why Enter did nothing

`FolderContents` declares `focus: true` on its grid and handles `Keys.onReturnPressed`, so on paper Enter already worked. It never fired, because the grid never had active focus.

The picker is an overlay inside the main window, and the main window's places sidebar was holding focus behind it. Printing the focused item on startup:

```
[T] fokus=VerticalFadeListView    <- the sidebar, not the file grid
```

Every key aimed at the file list was landing there, so arrow keys and type-ahead were lost the same way — not just Enter.

## What changed

The dialog claims focus when it becomes visible, and routes it by mode:

- **open dialog** → the file grid, and it selects the first entry when nothing is current, so a keyboard user has somewhere to start
- **save dialog** → the name field, with the basename selected, so typing replaces the stem and keeps the extension

## Verified

Real key events sent to the window; exit code `0` means a path was printed, `1` cancelled, `7` the dialog was still open when the harness gave up.

| dialog | keys | before | after |
|---|---|---|---|
| open | `Enter` on a file | `7` — nothing | `0` — `/home/vladi/atlas-keytest/haus.txt` |
| open | `Enter` on a folder | `7` — nothing | navigates into it, dialog stays open |
| `--directory-only` | `Enter` | `7` — nothing | `0` — `/home/vladi/atlas-keytest/Unterordner` |
| open | `Escape` | `1` | `1` — unchanged |

Focus after the change reads `VerticalFadeGridView` rather than the sidebar.

## The other two asks in that issue

**Escape closing the dialog already works** — `FileDialog.qml` binds it and the run above confirms exit code 1. If the report meant a popup *inside* the dialog rather than the dialog itself, I could not find one that traps Escape; worth naming which one.

**Enter opening with the default application already works too.** `onItemOpened` calls `AppIntegration.openWithDefault`, which is `QDesktopServices::openUrl` — the system default, with no special case for images anywhere in the codebase. If images behave differently on your setup that points at the desktop entry rather than at Atlas, and I would rather see the exact case before changing it.
