### PR TITLE
feat: ask whether to run an executable instead of handing it to the browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ qt_add_qml_module(atlas_app
         qml/components/dialogs/OperationsModal.qml
         qml/components/dialogs/BulkRenameModal.qml
         qml/components/dialogs/ConfirmDeleteModal.qml
+        qml/components/dialogs/RunFileModal.qml
         qml/components/dialogs/VectorBloomOverlay.qml
         qml/components/dialogs/RunnerGameModal.qml
         qml/components/media/ImageViewer.qml

--- a/qml/components/dialogs/RunFileModal.qml
+++ b/qml/components/dialogs/RunFileModal.qml
@@ -1,0 +1,158 @@
+import QtQuick
+import QtQuick.Layouts
+import "../"
+import "../controls"
+import atlas
+
+MouseArea {
+    id: root
+
+    property bool expanded: false
+    property string targetPath: ""
+
+    anchors.fill: parent
+    visible: opacity > 0.001
+    enabled: expanded
+    hoverEnabled: expanded
+    cursorShape: expanded ? Qt.ArrowCursor : undefined
+    z: 100
+
+    opacity: expanded ? 1.0 : 0.0
+    Behavior on opacity {
+        Anim {
+            type: Anim.FastEffects
+        }
+    }
+
+    onClicked: root.expanded = false
+    onWheel: wheel => wheel.accepted = true
+
+    Keys.onEscapePressed: root.expanded = false
+
+    onExpandedChanged: {
+        if (expanded) {
+            root.forceActiveFocus();
+        } else {
+            root.targetPath = "";
+            if (typeof splitContainer !== "undefined" && splitContainer) {
+                splitContainer.focusActiveView();
+            }
+        }
+    }
+
+    function open(path: string): void {
+        root.targetPath = path;
+        root.expanded = true;
+    }
+
+    function run(inTerminal: bool): void {
+        const path = root.targetPath;
+        root.expanded = false;
+        if (path.length > 0) {
+            AppIntegration.runExecutable(path, inTerminal);
+        }
+    }
+
+    function display(): void {
+        const path = root.targetPath;
+        root.expanded = false;
+        if (path.length > 0) {
+            AppIntegration.openWithDefault(path);
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Qt.alpha(Colours.palette.m3scrim, 0.4)
+    }
+
+    StyledRect {
+        anchors.centerIn: parent
+        width: Math.min(parent.width - 48, 460)
+        height: Math.min(parent.height - 32, modalCol.implicitHeight + Tokens.padding.large * 2)
+        implicitWidth: Math.min(parent.width - 48, 460)
+        implicitHeight: modalCol.implicitHeight + Tokens.padding.large * 2
+
+        radius: Tokens.rounding.large
+        color: Colours.palette.m3surfaceContainerHigh
+
+        scale: root.expanded ? 1.0 : 0.94
+
+        Behavior on scale {
+            Anim {
+                type: Anim.FastEffects
+                easing: Tokens.anim.standard
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: mouse => mouse.accepted = true
+            onWheel: wheel => wheel.accepted = true
+        }
+
+        ColumnLayout {
+            id: modalCol
+
+            anchors.fill: parent
+            anchors.margins: Tokens.padding.large
+            spacing: Tokens.spacing.medium
+
+            RowLayout {
+                spacing: Tokens.spacing.small
+
+                MaterialIcon {
+                    text: "terminal"
+                    color: Colours.palette.m3primary
+                    fontStyle: Tokens.font.icon.medium
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: qsTr("Run this file?")
+                    color: Colours.palette.m3onSurface
+                    font: Tokens.font.title.medium
+                }
+            }
+
+            StyledText {
+                Layout.fillWidth: true
+                text: qsTr("\"%1\" is executable. Run it as a program, or open it to look at its contents?")
+                    .arg(root.targetPath.split("/").pop())
+                color: Colours.palette.m3onSurfaceVariant
+                font: Tokens.font.body.medium
+                wrapMode: Text.Wrap
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Tokens.spacing.small
+
+                TextButton {
+                    type: ButtonBase.Text
+                    text: qsTr("Open")
+                    onClicked: root.display()
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                TextButton {
+                    type: ButtonBase.Tonal
+                    text: qsTr("In Terminal")
+                    onClicked: root.run(true)
+                }
+
+                TextButton {
+                    type: ButtonBase.Filled
+                    text: qsTr("Run")
+                    onClicked: root.run(false)
+                }
+            }
+        }
+    }
+
+    Keys.onReturnPressed: root.run(false)
+    Keys.onEnterPressed: root.run(false)
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -268,7 +268,10 @@ ApplicationWindow {
                             }
 
                             onItemOpened: (item, pane) => {
-                                AppIntegration.openWithDefault(item.path);
+                                if (AppIntegration.isRunnable(item.path))
+                                    runFileModal.open(item.path);
+                                else
+                                    AppIntegration.openWithDefault(item.path);
                             }
                         }
 
@@ -508,6 +511,11 @@ ApplicationWindow {
                 else
                     FileOperations.moveToTrash(paths);
             }
+        }
+
+        // Executable File Run Prompt
+        RunFileModal {
+            id: runFileModal
         }
 
         // Places & Devices Management Modal

--- a/src/core/appintegration.cpp
+++ b/src/core/appintegration.cpp
@@ -9,6 +9,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QMimeDatabase>
+#include <QMimeType>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QSet>
@@ -270,7 +271,7 @@ void AppIntegration::openWithApp(const QString& execLine, const QString& filePat
     QProcess::startDetached("/bin/sh", QStringList{ "-c", cmd });
 }
 
-void AppIntegration::openInTerminal(const QString& directoryPath) {
+static QString resolveTerminal() {
     QString term = qEnvironmentVariable("TERMINAL");
     if (term.isEmpty()) {
         static const QStringList candidates = { "foot", "kitty", "alacritty", "ghostty", "wezterm", "konsole", "gnome-terminal", "xterm" };
@@ -281,9 +282,54 @@ void AppIntegration::openInTerminal(const QString& directoryPath) {
             }
         }
     }
-    if (term.isEmpty()) term = "xterm";
+    if (term.isEmpty()) term = QStringLiteral("xterm");
+    return term;
+}
 
-    QProcess::startDetached(term, QStringList(), directoryPath);
+void AppIntegration::openInTerminal(const QString& directoryPath) {
+    QProcess::startDetached(resolveTerminal(), QStringList(), directoryPath);
+}
+
+bool AppIntegration::isRunnable(const QString& filePath) const {
+    const QFileInfo info(filePath);
+    if (!info.isFile() || !info.isExecutable())
+        return false;
+
+    QMimeDatabase db;
+    const QMimeType type = db.mimeTypeForFile(info);
+
+    static const QStringList runnable = {
+        QStringLiteral("application/x-executable"),
+        QStringLiteral("application/x-pie-executable"),
+        QStringLiteral("application/x-sharedlib"),
+        QStringLiteral("application/x-shellscript")
+    };
+    for (const QString& candidate : runnable) {
+        if (type.inherits(candidate))
+            return true;
+    }
+
+    if (!type.inherits(QStringLiteral("text/plain")))
+        return false;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+    return file.read(2) == QByteArrayLiteral("#!");
+}
+
+void AppIntegration::runExecutable(const QString& filePath, bool inTerminal) {
+    const QFileInfo info(filePath);
+    const QString target = info.absoluteFilePath();
+    const QString workingDir = info.absolutePath();
+
+    if (!inTerminal) {
+        QProcess::startDetached(target, QStringList(), workingDir);
+        return;
+    }
+
+    const QString term = resolveTerminal();
+    QProcess::startDetached(term, QStringList{ QStringLiteral("-e"), target }, workingDir);
 }
 
 void AppIntegration::openNewWindow(const QString& path) {

--- a/src/core/appintegration.hpp
+++ b/src/core/appintegration.hpp
@@ -29,6 +29,8 @@ public:
     Q_INVOKABLE void openWithDefault(const QString& filePath);
     Q_INVOKABLE void openWithApp(const QString& execLine, const QString& filePath);
     Q_INVOKABLE void openInTerminal(const QString& directoryPath);
+    Q_INVOKABLE bool isRunnable(const QString& filePath) const;
+    Q_INVOKABLE void runExecutable(const QString& filePath, bool inTerminal);
     Q_INVOKABLE void openNewWindow(const QString& path = QString());
 
     Q_INVOKABLE QVariantList getCustomActions(const QString& currentDir, const QStringList& selectedPaths, bool isDir, const QString& mimeType);


### PR DESCRIPTION
Fixes #84.

## The permission half works

I checked that first, since the title says "not able to make files executable". Driving `FileMetadata::applyPermissions` — the exact call the Properties dialog makes — against a 644 file:

```
before:  -rw-r--r--  644
after:   -rwxr-xr-x  755
```

So the checkbox grid and the chmod behind it are fine. Nothing to fix there.

## What was actually broken

Opening a file always went through `AppIntegration::openWithDefault`, which is `QDesktopServices::openUrl` — routing by MIME type. A shell script is `text/x-shellscript`, most desktops register no handler for it, and the fallback lands on the web browser. That is the Firefox download prompt in the report: Atlas has never executed anything, it only ever asked the desktop to open it.

## What changed

Opening a runnable file now asks, the way Thunar does — run it, run it in a terminal, or open it to read its contents. The process starts in the file's own directory.

![Run prompt](https://raw.githubusercontent.com/eximora-private/Atlas/assets/run-prompt.png)

## Which files count, and why it is narrow

The execute bit alone is **not** enough. NTFS and vfat mounts report mode `777` for every file they hold — the reporter in #77 is browsing exactly such a mount — so a prompt keyed on the permission alone would fire on every photo in a Windows partition. That would be worse than the bug.

A file qualifies only if it is executable **and** an ELF binary, a shared library, a registered shell script, or plain text starting with `#!`.

Verified against the cases that matter:

| file | mode | type | verdict |
|---|---|---|---|
| `skript-755.sh` | 755 | text/x-shellscript | runnable |
| `skript-644.sh` | 644 | text/x-shellscript | ordinary |
| `ohne-endung` | 755 | python, no extension | runnable — via shebang |
| `binaer-755` | 755 | x-pie-executable | runnable |
| `text-777.txt` | **777** | text/plain | ordinary |
| `bild-777.png` | **777** | image/png | ordinary |
| `archiv-777.zip` | **777** | octet-stream | ordinary |

The three 777 rows are the ones that keep this usable on a mounted Windows drive.

Execution itself is verified end to end: a script that writes a marker file was run through the prompt, and the marker appeared with the working directory set to the script's own folder.
