### PR TITLE
fix: draw desktop entry icons as icons, not as letters

### DIFF
--- a/qml/components/menus/ContextMenu.qml
+++ b/qml/components/menus/ContextMenu.qml
@@ -143,7 +143,7 @@ MouseArea {
                         if (AppController.menuShowSecondaryEditor && root.customActions && root.customActions.length > 0) {
                             for (let i = 0; i < root.customActions.length; ++i) {
                                 let ca = root.customActions[i];
-                                list.push({ text: ca.name, icon: ca.icon || "code", action: "custom:" + ca.id });
+                                list.push({ text: ca.name, icon: ca.icon || "code", themeIcon: ca.themeIcon === true, action: "custom:" + ca.id });
                             }
                         }
 
@@ -442,9 +442,16 @@ MouseArea {
                 spacing: Tokens.spacing.small
 
                 MaterialIcon {
+                    visible: modelData.themeIcon !== true
                     text: modelData.icon || ""
                     color: modelData.action === "delete" || modelData.action === "emptyTrash" ? Colours.palette.m3error : Colours.palette.m3onSurfaceVariant
                     fontStyle: Tokens.font.icon.small
+                }
+
+                CachingIconImage {
+                    visible: modelData.themeIcon === true
+                    implicitSize: 18
+                    source: visible ? FileUtils.iconForName(modelData.icon, "application-x-executable") : ""
                 }
 
                 StyledText {

--- a/src/core/appintegration.cpp
+++ b/src/core/appintegration.cpp
@@ -481,7 +481,8 @@ void AppIntegration::scanCustomActions() {
                             "all",
                             mainMime.split(';', Qt::SkipEmptyParts),
                             false,
-                            {}
+                            {},
+                            !aIcon.isEmpty()
                         });
                     }
                 }
@@ -494,7 +495,8 @@ void AppIntegration::scanCustomActions() {
                     "all",
                     mainMime.split(';', Qt::SkipEmptyParts),
                     false,
-                    {}
+                    {},
+                    !mainIcon.isEmpty()
                 });
             }
         }
@@ -527,6 +529,7 @@ QVariantList AppIntegration::getCustomActions(const QString& currentDir, const Q
         map["id"] = act.id;
         map["name"] = act.name;
         map["icon"] = act.icon;
+        map["themeIcon"] = act.themeIcon;
         map["isScript"] = act.isScript;
         list.append(map);
     }

--- a/src/core/appintegration.hpp
+++ b/src/core/appintegration.hpp
@@ -68,6 +68,7 @@ private:
         QStringList mimeTypes;
         bool isScript = false;
         QString scriptPath;
+        bool themeIcon = false;
     };
 
     QList<DesktopApp> m_apps;


### PR DESCRIPTION
Fixes the garbled context menu row reported in #85.

## What the screenshot shows

```
PREFERENCES-⧉TOP-FONT-INSTALLER          Install...
```

That is not a corrupted label. It is a **freedesktop icon name** being drawn as text, with the real label — "Install Font" — pushed off the right edge by it.

Actions discovered from `.desktop` files carry an `Icon=` key holding a theme icon name: `preferences-desktop-font-installer`, `firefox`, `org.kde.something`. The menu passed that value straight into `MaterialIcon`, which renders text in the Material Symbols font. With no glyph for the name, the font falls back per character and draws the letters. The reporter has the KDE font installer service menu on their system, so that is what surfaced.

![before and after](https://raw.githubusercontent.com/eximora-private/Atlas/assets/menu-icons.png)

Top is current `main` reproduced with a service menu file, bottom is this branch.

## The fix

Actions scanned from desktop files now carry a flag saying their icon comes from the theme, and the menu draws those through `CachingIconImage` and `FileUtils.iconForName` — the same path the Open With dialog already uses. The built-in tool entries (`pie_chart`, `code`, …) keep their Material names and their existing rendering.

The flag is set **at the source**, in the desktop file scanner, rather than guessed from the name. Neither shape is decisive: `code` is both a valid Material symbol and a plausible theme icon name, and `firefox` is neither hyphenated nor a glyph. Only the scanner knows where the string came from.

## Verified

Reproduced with a service menu in `~/.local/share/atlas/actions`:

```
[A] name='Install Font' icon='preferences-desktop-font-installer' themeIcon=ja
```

and rendered both ways, which is the image above. Falls back to `application-x-executable` when the theme has no matching icon.

## The rest of #85

The missing type-ahead in the picker is a focus bug, fixed separately in #86 — the file grid never held keyboard focus, so no key reached it. Ctrl+1/2/3 view switching in the picker is genuinely missing and not addressed here. Startup timings are in #77.
