### PR TITLE
fix: stop file names reaching the shell as code

### DIFF
--- a/src/core/appintegration.cpp
+++ b/src/core/appintegration.cpp
@@ -256,13 +256,19 @@ void AppIntegration::openWithDefault(const QString& filePath) {
     QDesktopServices::openUrl(QUrl::fromLocalFile(filePath));
 }
 
+static QString shellQuote(const QString& value) {
+    QString escaped = value;
+    escaped.replace(QLatin1Char('\''), QLatin1String("'\\''"));
+    return QLatin1Char('\'') + escaped + QLatin1Char('\'');
+}
+
 void AppIntegration::openWithApp(const QString& execLine, const QString& filePath) {
     QString cmd = execLine;
     // Replace %f, %F, %u, %U with file path
-    cmd.replace("%f", QString("\"%1\"").arg(filePath));
-    cmd.replace("%F", QString("\"%1\"").arg(filePath));
-    cmd.replace("%u", QString("\"%1\"").arg(QUrl::fromLocalFile(filePath).toString()));
-    cmd.replace("%U", QString("\"%1\"").arg(QUrl::fromLocalFile(filePath).toString()));
+    cmd.replace("%f", shellQuote(filePath));
+    cmd.replace("%F", shellQuote(filePath));
+    cmd.replace("%u", shellQuote(QUrl::fromLocalFile(filePath).toString()));
+    cmd.replace("%U", shellQuote(QUrl::fromLocalFile(filePath).toString()));
     cmd.remove("%i");
     cmd.remove("%c");
     cmd.remove("%k");
@@ -477,7 +483,7 @@ void AppIntegration::scanCustomActions() {
                 "script:" + fi.absoluteFilePath(),
                 displayName,
                 "terminal",
-                QString("\"%1\" %F").arg(fi.absoluteFilePath()),
+                shellQuote(fi.absoluteFilePath()) + QStringLiteral(" %F"),
                 "all",
                 {},
                 true,
@@ -604,24 +610,24 @@ void AppIntegration::executeCustomAction(const QString& actionId, const QString&
     QString quotedUrls;
     for (const QString& p : selectedPaths) {
         if (!quotedPaths.isEmpty()) quotedPaths += " ";
-        quotedPaths += QString("\"%1\"").arg(p);
+        quotedPaths += shellQuote(p);
 
         if (!quotedUrls.isEmpty()) quotedUrls += " ";
-        quotedUrls += QString("\"%1\"").arg(QUrl::fromLocalFile(p).toString());
+        quotedUrls += shellQuote(QUrl::fromLocalFile(p).toString());
     }
     if (quotedPaths.isEmpty()) {
-        quotedPaths = QString("\"%1\"").arg(currentDir);
-        quotedUrls = QString("\"%1\"").arg(QUrl::fromLocalFile(currentDir).toString());
+        quotedPaths = shellQuote(currentDir);
+        quotedUrls = shellQuote(QUrl::fromLocalFile(currentDir).toString());
     }
 
     QString cmd = targetAct->exec;
-    cmd.replace("%f", QString("\"%1\"").arg(primaryPath));
+    cmd.replace("%f", shellQuote(primaryPath));
     cmd.replace("%F", quotedPaths);
-    cmd.replace("%u", QString("\"%1\"").arg(QUrl::fromLocalFile(primaryPath).toString()));
+    cmd.replace("%u", shellQuote(QUrl::fromLocalFile(primaryPath).toString()));
     cmd.replace("%U", quotedUrls);
-    cmd.replace("%d", QString("\"%1\"").arg(dirPath));
-    cmd.replace("%D", QString("\"%1\"").arg(dirPath));
-    cmd.replace("%n", QString("\"%1\"").arg(QFileInfo(primaryPath).fileName()));
+    cmd.replace("%d", shellQuote(dirPath));
+    cmd.replace("%D", shellQuote(dirPath));
+    cmd.replace("%n", shellQuote(QFileInfo(primaryPath).fileName()));
     cmd.remove("%i");
     cmd.remove("%c");
     cmd.remove("%k");


### PR DESCRIPTION
Fixes #89.

Every path substituted into an `Exec` line was wrapped in **double** quotes before being handed to `sh -c`. Double quotes do not stop command substitution, and they do not survive a double quote in the name. Single quotes stop both — nothing expands inside them, and an embedded single quote is handled by closing, escaping and reopening.

## Before and after

Same substitution, same shell, only the quoting differs. `id -u` prints `1000` here, so anywhere it appears the file name executed.

| file name | before | after |
|---|---|---|
| `urlaub$(id -u).txt` | `.../urlaub1000.txt` — **ran** | `.../urlaub$(id -u).txt` |
| ``lied`id -u`.mp3`` | `.../lied1000.mp3` — **ran** | ``.../lied`id -u`.mp3`` |
| `quote";id -u;".txt` | broke out of the quoting, `1000` on its own line | `.../quote";id -u;".txt` |
| `ganz normal.txt` | unchanged | unchanged |
| `mit'apostroph.txt` | unchanged | unchanged |

The last two matter as much as the first three: a fix that mangles ordinary names with a space or an apostrophe would be no fix at all.

## End to end

Through the real `openWithApp`, with the file actually on disk and a stand-in application that records the argument it receives:

```
without the fix:  DURCHGEBROCHEN.txt appeared, argument arrived as  urlaub.txt
with the fix:     nothing ran,        argument arrived as  urlaub$(touch …).txt
```

The path now reaches the target application verbatim, which is also the correct behaviour independent of the security question — before, any name containing shell syntax was silently mangled on its way to the application.

## Scope

One helper, applied to every substitution: `%f`, `%F`, `%u`, `%U`, `%d`, `%D`, `%n`, in both `openWithApp` and `executeCustomAction`, plus the script path in the action scanner. Nothing else changes — `Exec` lines keep working exactly as they do today, including ones that use shell syntax of their own, which a switch to `startDetached(program, arguments)` would have broken.

## Adjacent, not fixed here

`executeCustomAction` builds a `QProcess`, sets the environment on it — `NAUTILUS_SCRIPT_SELECTED_FILE_PATHS`, `ATLAS_SELECTED_PATHS` and the rest — and then calls the **static** `QProcess::startDetached`, which ignores that object entirely. The local `QProcess` is destroyed unused, so scripts never receive any of those variables. Worth its own change; I did not want it in a security fix.
